### PR TITLE
chore(deps): drop pip>=24.0 from runtime deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "pebble==5.1.3",
     "pyyaml<7.0.0,>=6.0.0",
     "python-dotenv==0.21.1",
-    "pip>=24.0",
     # Custom-tool AI / media deps — exact pins per agent-repo rule
     # (each tool is configured against a specific version).
     "openai==1.82.0",

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,6 @@ dependencies = [
     { name = "openapi-spec-validator" },
     { name = "pebble" },
     { name = "pillow" },
-    { name = "pip" },
     { name = "prometheus-client" },
     { name = "py-ecc" },
     { name = "pytest" },
@@ -95,7 +94,6 @@ requires-dist = [
     { name = "openapi-spec-validator", specifier = ">=0.7.0,<0.8.0" },
     { name = "pebble", specifier = "==5.1.3" },
     { name = "pillow", specifier = "==12.2.0" },
-    { name = "pip", specifier = ">=24.0" },
     { name = "prometheus-client", specifier = "==0.23.1" },
     { name = "py-ecc", specifier = ">=8,<10" },
     { name = "pytest", specifier = "==8.4.2" },
@@ -1426,7 +1424,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2860,15 +2858,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
     { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
     { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
-]
-
-[[package]]
-name = "pip"
-version = "26.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pip is a build/install tool and shouldn't be in the app's runtime dependency list. Mirrors the cleanup done in meme-ooorr commit `11acfdad1` per #436 rule.

`uv lock` removed the corresponding entry from `uv.lock`. No `tox.ini` change (the tox-internal `pip` in liccheck/freeze envs is a separate dep). No `autonomy packages lock` change — package hashes are unaffected.

## Test plan

- [ ] CI green (check-dependencies, tests, liccheck)
- [ ] `uv sync` produces a working venv
- [ ] `autonomy --version` still works (sanity check for the jmoreira bug from market-resolver `aabf26b2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)