### PR TITLE
chore(deps): bump mech v0.34.4 -> v0.34.5

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -5,8 +5,8 @@
         "custom/agents_fun/google_image_gen/0.1.0": "bafybeiczdxwwottbwphberpnrlv6abp3g4ccin265qnkkd3j56h3rjvrmi",
         "custom/agents_fun/recraft_image_gen/0.1.0": "bafybeiat4d33kqap7pmrh54ckj5dsdamxbxsyttrgocejqiluitfphyj6e",
         "custom/agents_fun/google_video_gen/0.1.0": "bafybeifqegajjjjfcxc6yc6jebl3x4dchcxlpw2o5kxxtadtguu2hipy2e",
-        "agent/valory/mech_agents_fun/0.1.0": "bafybeihyalgkvsy7htajj4oef6p2luzjvhgqt6pzlmqc27sq5zleovm6oe",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeigm2fvlvxcirbawcdj5or2fmi6eqnagsknx4wgermnhayf63gt7vm"
+        "agent/valory/mech_agents_fun/0.1.0": "bafybeicsssvb5uqc7baqdrckk5sip6rtc43smgktiskbi654hichqpp2mu",
+        "service/valory/mech_agents_fun/0.1.0": "bafybeia7xc2r6zsi2nis2u5say5bs7kntidvmgibllpeu2v2gpcmdhdyvi"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",
@@ -39,17 +39,17 @@
         "connection/valory/abci/0.1.0": "bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi",
         "connection/valory/ipfs/0.1.0": "bafybeidob3tcdebjbm4ovwqoz4v2egf7nvoui3hu5on4o3apfchr6rpwwa",
         "connection/valory/kv_store/0.1.0": "bafybeib2tvoui6kndvrd2gpvs55rizpjee7mqjtjsfbr6fdp5hxslh6gd4",
-        "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
-        "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
+        "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
+        "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
         "skill/valory/abstract_abci/0.1.0": "bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi",
         "skill/valory/abstract_round_abci/0.1.0": "bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m",
         "skill/valory/registration_abci/0.1.0": "bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi",
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
-        "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeiatph3obd4vomjsft7civq7iukue5c3q63t44cghvrfghca65aoma",
-        "skill/valory/task_execution/0.1.0": "bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a"
+        "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
+        "skill/valory/mech_abci/0.1.0": "bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm",
+        "skill/valory/task_execution/0.1.0": "bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve"
     }
 }

--- a/packages/valory/agents/mech_agents_fun/aea-config.yaml
+++ b/packages/valory/agents/mech_agents_fun/aea-config.yaml
@@ -39,16 +39,16 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeiatph3obd4vomjsft7civq7iukue5c3q63t44cghvrfghca65aoma
+- valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
+- valory/mech_abci:0.1.0:bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm
-- valory/task_submission_abci:0.1.0:bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a
+- valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
+- valory/task_execution:0.1.0:bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza
+- valory/task_submission_abci:0.1.0:bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay
+- valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m
 customs:
 - agents_fun/google_image_gen:0.1.0:bafybeiczdxwwottbwphberpnrlv6abp3g4ccin265qnkkd3j56h3rjvrmi
 - agents_fun/short_maker:0.1.0:bafybeialdibotrsz7l64346iwgczuaqhk3y7ge6ozyzadpgxvhswz7gwpa

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech_agents_fun:0.1.0:bafybeihyalgkvsy7htajj4oef6p2luzjvhgqt6pzlmqc27sq5zleovm6oe
+agent: valory/mech_agents_fun:0.1.0:bafybeicsssvb5uqc7baqdrckk5sip6rtc43smgktiskbi654hichqpp2mu
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ override-dependencies = [
 # author so canonical env vars resolve sensibly.
 packages_paths = "packages/valory"
 # Third-party skills/contracts on disk are synced from mech upstream.
-upstream_pins = ["valory-xyz/mech@v0.34.4"]
+upstream_pins = ["valory-xyz/mech@v0.34.5"]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"
 # Customs are file-form (no per-pkg tests/ dir). The only first-party
 # tests live under tests/; without pinning, auto-discovery picks up

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,10 @@
 ; string-strict matching so the form must agree on both sides. Plus
 ; lint-only werkzeug/attrs not in pyproject.
 extra_deps =
+    eth-abi==6.0.0b1
+    eth-account==0.13.7
+    eth-keys==0.8.0b1
+    eth-utils==6.0.0
     protobuf<7,>=5
     web3<8,>=7.0.0
     aiohttp<4.0.0,>=3.8.5


### PR DESCRIPTION
## Summary

- Bumps mech to [v0.34.5](https://github.com/valory-xyz/mech/releases/tag/v0.34.5) — the offchain `/send_signed_requests` signature verifier (mech PR #476).
- Six third-party skill hashes updated: `contract_subscription`, `delivery_rate_abci`, `mech_abci`, `task_execution`, `task_submission_abci`, `websocket_client`. `autonomy packages lock` cascaded the `mech_agents_fun` agent + service hashes.
- `tox.ini` gains `eth-abi==6.0.0b1` / `eth-account==0.13.7` / `eth-keys==0.8.0b1` pins so `aea-helpers check-dependencies` string-matches the `task_execution` skill.yaml deps that the sig verifier needs.

## What v0.34.5 brings on the mech side

- EIP-712 `request_id` recomputation on accept + ecrecover for EOAs + tri-state EIP-1271 (`VALID` / `DECLINED` / `CALL_FAILED`) for Safes.
- Three-state per-sender nonce accounting (`accepted` -> `settling` -> chain), with orphan reconciliation that evicts pending / done tasks whose slot the on-chain rail consumed.
- Wall-clock deadline on the on-path RPCs, per-sender in-flight cap, handler-wide defensive 503, and ADDRESS_RE / SIGNATURE_RE / IPFS_HASH_RE ingress guards.

## Test plan

- [x] `autonomy packages sync --update-packages` — six third-party skills pulled from IPFS
- [x] `autonomy packages lock` — no drift after re-lock
- [x] `tomte tox -e check-hash -e check-packages -e check-dependencies` — all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)