### PR TITLE
fix(release): switch docker-run-action to the fork mech-predict uses

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-versions }}
-      - uses: addnab/docker-run-action@v3
+          python-version: ${{ matrix.python-version }}
+      - uses: maus007/docker-run-action-fork@v1
         with:
             image: valory/open-autonomy-user:0.21.26
             options: -v ${{ github.workspace }}:/work
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up tag and vars
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
             image: valory/open-autonomy-user:0.21.26
             options: -v ${{ github.workspace }}:/work
@@ -65,7 +65,7 @@ jobs:
               echo DEFAULT_IMAGE_TAG=$(cat packages/packages.json | grep agent/ | awk -F: '{print $2}' | tr -d '", ' | head -n 1) >> env.sh
               cat env.sh
 
-      - uses: addnab/docker-run-action@v3
+      - uses: maus007/docker-run-action-fork@v1
         name: Build Images
         with:
             image: valory/open-autonomy-user:0.21.26
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-versions }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           sudo apt-get update --fix-missing
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-versions }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           sudo apt-get update --fix-missing


### PR DESCRIPTION
## Summary

Publish Docker Images has been failing since v0.3.2 (Aug 11), silently pinning `valory/oar-mech_agents_fun` on Docker Hub to v0.2.6 (May 7) — 3 months stuck. `Build Images` step hangs for ~15 minutes after "Installing the necessary python dependencies!" then gets killed at ~17 min. No output between "Installing…" and the kill.

Root cause candidate: `addnab/docker-run-action@v3` has an issue (output flushing / SIGKILL handling) that surfaces during long-running pip installs inside docker-in-docker. mech-predict's identical release workflow uses [`maus007/docker-run-action-fork@v1`](https://github.com/valory-xyz/mech/commit/56931c21) and its docker publish is healthy (`valory/oar-mech_predict:0.21.20` → 200 on Docker Hub).

## Diff

Two small changes in `.github/workflows/release.yaml`:

1. `addnab/docker-run-action@v3` → `maus007/docker-run-action-fork@v1` (3 uses)
2. `matrix.python-versions` (typo, plural) → `matrix.python-version` (singular) (3 uses)

Rest of the file untouched (runner OS, action versions, etc.).

## Follow-up if this works

Re-cut a release (v0.3.4). Confirm `valory/oar-mech_agents_fun:0.3.4` lands on Docker Hub. Then bump `base_mech.env` in agent-deployments (currently reverted in [agent-deployments PR#324](https://github.com/valory-xyz/agent-deployments/pull/324) waiting on this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)