### PR TITLE
fix(release): add shell: bash to Set up tag and vars step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,7 @@ jobs:
         with:
             image: valory/open-autonomy-user:0.21.26
             options: -v ${{ github.workspace }}:/work
+            shell: bash
             run: |
               echo "Setting Tag Images"
               cd /work


### PR DESCRIPTION
## Summary

Follow-up to #53. After switching to `maus007/docker-run-action-fork@v1`, the release re-run for v0.3.3 got past `Push Packages` but died at `Set up tag and vars` with:

```
sh: 1: Syntax error: ";" unexpected
```

The step's run block has bash-specific `if [ $? -eq 0 ]; then ... fi` around tag detection, but the docker-run-action-fork defaults to `sh` when no `shell:` is set. Only the `Build Images` step already had `shell: bash` — the others didn't.

One-line fix: add `shell: bash` to `Set up tag and vars`. `Push Packages` doesn't need it (no bash-specific syntax in that block).

Failed re-run: https://github.com/valory-xyz/mech-agents-fun/actions/runs/31621902389

## Follow-up

Re-cut v0.3.4 (or re-trigger v0.3.3) once this merges. Confirm `valory/oar-mech_agents_fun:<version>` lands on Docker Hub. Then re-bump `base_mech.env` in agent-deployments (reverted in [PR#324](https://github.com/valory-xyz/agent-deployments/pull/324)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)