### PR TITLE
chore(deps): bump mech v0.34.5 -> v0.34.6

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -5,8 +5,8 @@
         "custom/agents_fun/google_image_gen/0.1.0": "bafybeiczdxwwottbwphberpnrlv6abp3g4ccin265qnkkd3j56h3rjvrmi",
         "custom/agents_fun/recraft_image_gen/0.1.0": "bafybeiat4d33kqap7pmrh54ckj5dsdamxbxsyttrgocejqiluitfphyj6e",
         "custom/agents_fun/google_video_gen/0.1.0": "bafybeifqegajjjjfcxc6yc6jebl3x4dchcxlpw2o5kxxtadtguu2hipy2e",
-        "agent/valory/mech_agents_fun/0.1.0": "bafybeicsssvb5uqc7baqdrckk5sip6rtc43smgktiskbi654hichqpp2mu",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeia7xc2r6zsi2nis2u5say5bs7kntidvmgibllpeu2v2gpcmdhdyvi"
+        "agent/valory/mech_agents_fun/0.1.0": "bafybeibpsyxjnktoharhnb6vorngjgp7vqwx7z3poei56iq5sszjie2ck4",
+        "service/valory/mech_agents_fun/0.1.0": "bafybeico7lqbnzolvllvumg6fcg6zwessayitjzw2upswxxzjq236icagy"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",
@@ -48,8 +48,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm",
-        "skill/valory/task_execution/0.1.0": "bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve"
+        "skill/valory/mech_abci/0.1.0": "bafybeicdhperwghzemntlzc3evrpnlvbuzjw3bmrsstmpfiwynwyxn7bz4",
+        "skill/valory/task_execution/0.1.0": "bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a"
     }
 }

--- a/packages/valory/agents/mech_agents_fun/aea-config.yaml
+++ b/packages/valory/agents/mech_agents_fun/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
-- valory/mech_abci:0.1.0:bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm
+- valory/mech_abci:0.1.0:bafybeicdhperwghzemntlzc3evrpnlvbuzjw3bmrsstmpfiwynwyxn7bz4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/task_execution:0.1.0:bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza
-- valory/task_submission_abci:0.1.0:bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve
+- valory/task_execution:0.1.0:bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy
+- valory/task_submission_abci:0.1.0:bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech_agents_fun:0.1.0:bafybeicsssvb5uqc7baqdrckk5sip6rtc43smgktiskbi654hichqpp2mu
+agent: valory/mech_agents_fun:0.1.0:bafybeibpsyxjnktoharhnb6vorngjgp7vqwx7z3poei56iq5sszjie2ck4
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ override-dependencies = [
 # author so canonical env vars resolve sensibly.
 packages_paths = "packages/valory"
 # Third-party skills/contracts on disk are synced from mech upstream.
-upstream_pins = ["valory-xyz/mech@v0.34.5"]
+upstream_pins = ["valory-xyz/mech@v0.34.6"]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"
 # Customs are file-form (no per-pkg tests/ dir). The only first-party
 # tests live under tests/; without pinning, auto-discovery picks up


### PR DESCRIPTION
## Summary

- Bumps mech to [v0.34.6](https://github.com/valory-xyz/mech/releases/tag/v0.34.6) — the 402 asset-address auto-derive from mech PR #477.
- Three third-party skill hashes updated: `mech_abci`, `task_execution`, `task_submission_abci`. `autonomy packages lock` cascaded the `mech_agents_fun` agent + service hashes.

## What v0.34.6 brings

- The mech's 402 challenge now reads the balance tracker's on-chain `token()` at build time (cached per tracker address; transient RPC failures do not poison the cache). Removes the dead `payment_type_to_asset_address` map primitive.
- Token-payment mechs (Polygon USDC, Optimism USDC) now report the correct ERC-20 asset in the 402 body instead of falling back to native `0x0000...0000`, so mech-interact's asset-match guard admits the deposit as intended.

## Test plan

- [x] `autonomy packages sync --update-packages` — three third-party skills pulled from IPFS
- [x] `autonomy packages lock` — no drift after re-lock
- [x] `tomte tox -e check-hash -e check-packages -e check-dependencies` — all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)