### PR TITLE
fix(release): drop dead if/then/else from Set up tag and vars step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,14 +52,10 @@ jobs:
               cd /work
               apt-get update && apt-get install git -y || exit 1
               git config --global --add safe.directory /work
-              export TAG=$(git describe --exact-match --tags $(git rev-parse HEAD)) || exit 1
-              if [ $? -eq 0 ]; then
-                  export TAG=`echo $TAG | sed 's/^v//'`
-              else
-                  echo "You are not on a tagged branch"
-                  exit 1
-              fi
-              echo VERSION=$TAG> env.sh
+              head=$(git rev-parse HEAD)
+              TAG=$(git describe --exact-match --tags "$head") || exit 1
+              export TAG=$(echo "$TAG" | sed 's/^v//')
+              echo VERSION=$TAG > env.sh
               echo AUTHOR=$(grep 'service/' packages/packages.json | awk -F/ '{print $2}' | head -1) >> env.sh
               echo SERVICE=$(grep 'service/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh
               echo AGENT=$(grep 'agent/' packages/packages.json | awk -F/ '{print $3}' | head -1) >> env.sh


### PR DESCRIPTION
## Summary

Third follow-up in the release-flow fix chain (after #53 and #54). v0.3.4 release failed at `Set up tag and vars` with:

```
bash: -c: line 1: syntax error near unexpected token \`;'
bash: -c: line 1: `... if [ $? -eq 0 ]; then;    export TAG=...;else;    echo "...";    exit 1;fi;...'
```

`maus007/docker-run-action-fork@v1` **flattens** the multi-line `run:` block into a single-line semicolon-joined command before handing to the shell. That breaks `if/then/else/fi` — flattening produces `if [ $? -eq 0 ]; then; export ...` and no shell (including bash) accepts a semicolon immediately after `then` or `else`.

The `if` block was dead code anyway: `export TAG=$(git describe ...) || exit 1` on the previous line already exits on failure. `$?` after that will always be 0 (or the process has already exited). Refactored to mech-predict's shape — single `git describe` + assign + export, no branch. Same behaviour, survives flattening.

Failed re-run: https://github.com/valory-xyz/mech-agents-fun/actions/runs/31633551762

## Note on next likely failure

Assuming this merges and Build Images passes, the release will hit `Docker login` next which has been failing since v0.3.1 with:

```
Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: incorrect username or password
```

The `DOCKER_USER` / `DOCKER_PASSWORD` repo secrets need a valid Docker Hub credential pair. That's a repo-admin action, not something this PR can fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)