### PR TITLE
fix(agent): narrow pip dependencies to avoid resolution-too-deep

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -5,8 +5,8 @@
         "custom/agents_fun/google_image_gen/0.1.0": "bafybeiczdxwwottbwphberpnrlv6abp3g4ccin265qnkkd3j56h3rjvrmi",
         "custom/agents_fun/recraft_image_gen/0.1.0": "bafybeiat4d33kqap7pmrh54ckj5dsdamxbxsyttrgocejqiluitfphyj6e",
         "custom/agents_fun/google_video_gen/0.1.0": "bafybeifqegajjjjfcxc6yc6jebl3x4dchcxlpw2o5kxxtadtguu2hipy2e",
-        "agent/valory/mech_agents_fun/0.1.0": "bafybeibpsyxjnktoharhnb6vorngjgp7vqwx7z3poei56iq5sszjie2ck4",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeico7lqbnzolvllvumg6fcg6zwessayitjzw2upswxxzjq236icagy"
+        "agent/valory/mech_agents_fun/0.1.0": "bafybeieyfluhvxkui3wme34tdcddpngdbdjncnlldxdooiilqhqbk5ao7u",
+        "service/valory/mech_agents_fun/0.1.0": "bafybeib7qzuflpgik44xyvqqzveym7cwu22jviz5rc675vh5ha5q4vqtke"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",

--- a/packages/valory/agents/mech_agents_fun/aea-config.yaml
+++ b/packages/valory/agents/mech_agents_fun/aea-config.yaml
@@ -83,37 +83,67 @@ logging_config:
       - console
       propagate: true
 dependencies:
+  PyYAML:
+    version: '>=6'
   aiohttp:
     version: <4.0.0,>=3.8.5
-  hypothesis:
-    version: ==6.21.6
-  open-aea-ledger-ethereum:
-    version: ==2.2.9
-  openai:
-    version: ==1.82.0
-  replicate:
-    version: ==0.28.0
-  moviepy:
-    version: ==1.0.3
   anthropic:
     version: ==0.21.3
+  asn1crypto:
+    version: <1.5.0,>=1.4.0
+  ecdsa:
+    version: '>=0.15'
+  google-api-core: {}
   google-api-python-client:
     version: ==2.130.0
-  tiktoken:
-    version: ==0.12.0
-  requests:
-    version: ==2.32.5
-  httpx:
-    version: ==0.28.1
   google-genai:
     version: ==1.17.0
-  pillow:
-    version: ==12.2.0
-  pebble:
-    version: ==5.1.3
-  google-api-core: {}
+  grpcio:
+    version: ==1.78.0
+  httpx:
+    version: ==0.28.1
+  hypothesis:
+    version: ==6.21.6
+  moviepy:
+    version: ==1.0.3
   open-aea-cli-ipfs:
     version: ==2.2.9
+  open-aea-ledger-cosmos:
+    version: ==2.2.9
+  open-aea-ledger-ethereum:
+    version: ==2.2.9
+  open-aea-test-autonomy:
+    version: ==0.21.26
+  openai:
+    version: ==1.82.0
+  openapi-core:
+    version: <0.23,>=0.22
+  openapi-spec-validator:
+    version: <0.8.0,>=0.7.0
+  pebble:
+    version: <6,>=5.1
+  pillow:
+    version: ==12.2.0
+  prometheus_client:
+    version: <0.24,>=0.23.1
+  protobuf:
+    version: <7,>=5
+  py-ecc:
+    version: <10,>=8
+  pytest:
+    version: <10,>=8.2
+  pytest-asyncio:
+    version: '>=1.3'
+  replicate:
+    version: ==0.28.0
+  requests:
+    version: ==2.32.5
+  tiktoken:
+    version: ==0.12.0
+  web3:
+    version: <8,>=7.15.0
+  websocket_client:
+    version: <1,>=0.32.0
 default_connection: null
 ---
 public_id: valory/websocket_client:0.1.0:bafybeiexove4oqyhoae5xmk2hilskthosov5imdp65olpgj3cfrepbouyy

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech_agents_fun:0.1.0:bafybeibpsyxjnktoharhnb6vorngjgp7vqwx7z3poei56iq5sszjie2ck4
+agent: valory/mech_agents_fun:0.1.0:bafybeieyfluhvxkui3wme34tdcddpngdbdjncnlldxdooiilqhqbk5ao7u
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

The v0.3.4 release Docker build failed with pip's new `resolution-too-deep` error introduced in pip 26.2.1:

```
error: resolution-too-deep
× Dependency resolution exceeded maximum depth
╰─> Pip cannot resolve the current dependencies as the dependency graph is too complex for pip to solve efficiently.
```

Root cause: several agent dependencies were unpinned or only loosely bounded (`google-api-core: {}`, `ecdsa`, `pytest-asyncio`, `certifi`, `multidict`, etc.), and combined with `open-aea-test-autonomy` requiring the `open-autonomy[docker]` extra that has since been removed from every 0.21.X release, pip backtracked across the full version history looking for a satisfiable set and gave up.

## Change

Adds/tightens the following pins in `packages/valory/agents/mech_agents_fun/aea-config.yaml` under `dependencies:`, mirroring the working set from mech's aea-config:

- `PyYAML>=6`, `asn1crypto<1.5.0,>=1.4.0`, `ecdsa>=0.15`, `grpcio==1.78.0`
- `open-aea-ledger-cosmos==2.2.9`, `open-aea-test-autonomy==0.21.26`
- `openapi-core<0.23,>=0.22`, `openapi-spec-validator<0.8.0,>=0.7.0`
- `pebble<6,>=5.1`, `prometheus_client<0.24,>=0.23.1`, `protobuf<7,>=5`
- `py-ecc<10,>=8`, `pytest<10,>=8.2`, `pytest-asyncio>=1.3`
- `web3<8,>=7.15.0`, `websocket_client<1,>=0.32.0`

Regenerated `packages.json` via `autonomy packages lock`.

## Test plan

- [x] `autonomy packages lock --check` passes locally
- [ ] Once merged, re-run the v0.3.4 (or cut v0.3.5) release and confirm Docker image build succeeds