### PR TITLE
chore: restore ALLOWED_TOOLS in google stubs

### DIFF
--- a/packages/agents_fun/customs/google_image_gen/component.yaml
+++ b/packages/agents_fun/customs/google_image_gen/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeidnpzfuhbztaogflzlzwi7g7oyt2t5pcx6ayl5xuuixsq2nbt3vcu
-  google_image_gen.py: bafybeicbc5bfbh6ov2o7h45tffut274kupi7go46g5rppx42cgtf4ac2ci
+  google_image_gen.py: bafybeigevajo3pyzwr2syowzalfb54gwdr57hlrdtse77zljvrljkjcewy
 fingerprint_ignore_patterns: []
 entry_point: google_image_gen.py
 callable: run

--- a/packages/agents_fun/customs/google_image_gen/google_image_gen.py
+++ b/packages/agents_fun/customs/google_image_gen/google_image_gen.py
@@ -22,6 +22,8 @@ from typing import Any, Dict, Optional, Tuple
 
 MechResponse = Tuple[str, Optional[str], Optional[Dict[str, Any]], Any, Any]
 
+ALLOWED_TOOLS = ["google_image_gen"]
+
 
 def run(**kwargs: Any) -> MechResponse:
     """Stubbed out: google-genai removed."""

--- a/packages/agents_fun/customs/google_video_gen/component.yaml
+++ b/packages/agents_fun/customs/google_video_gen/component.yaml
@@ -6,7 +6,7 @@ description: A tool to generate shortvideos from text using Google Generative AI
 license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
-  google_video_gen.py: bafybeih3u6f2znqzjqus6utg7zognsle6bayuwxprta3tvf6a2qesr42t4
+  google_video_gen.py: bafybeiholgy3nxptav6pumetnbnewiceqznjpiomdsgaxlhwdx7vowyepq
 fingerprint_ignore_patterns: []
 entry_point: google_video_gen.py
 callable: run

--- a/packages/agents_fun/customs/google_video_gen/google_video_gen.py
+++ b/packages/agents_fun/customs/google_video_gen/google_video_gen.py
@@ -22,6 +22,8 @@ from typing import Any, Dict, Optional, Tuple
 
 MechResponse = Tuple[str, Optional[str], Optional[Dict[str, Any]], Any, Any]
 
+ALLOWED_TOOLS = ["google_video_gen"]
+
 
 def run(**kwargs: Any) -> MechResponse:
     """Stubbed out: google-genai removed."""

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,12 +2,12 @@
     "dev": {
         "custom/agents_fun/short_maker/0.1.0": "bafybeialdibotrsz7l64346iwgczuaqhk3y7ge6ozyzadpgxvhswz7gwpa",
         "custom/agents_fun/stability_ai_request/0.1.0": "bafybeihndmvigf7vufvwbg24mbdhgbqqlrbuanr6sm5qtoavvmbautsd3e",
-        "custom/agents_fun/google_image_gen/0.1.0": "bafybeibkts5sjnrxysabqjznay3bm6hj5hzfvwopvwvb2nbjxjv2ow6rmu",
+        "custom/agents_fun/google_image_gen/0.1.0": "bafybeigh3ekuttzvxi6otzxu2c6yzkliysluqk63gluwl7igz4dpuvyxx4",
         "custom/agents_fun/recraft_image_gen/0.1.0": "bafybeiat4d33kqap7pmrh54ckj5dsdamxbxsyttrgocejqiluitfphyj6e",
-        "custom/agents_fun/google_video_gen/0.1.0": "bafybeid5joxmshtizrlflhepnym25gi6totyidywqalictudmwgmwionuy",
+        "custom/agents_fun/google_video_gen/0.1.0": "bafybeidzjajkqaff2pnrpd4gq3kgk2l7jwfpyamypvxjnuhm2s7wfscnla",
         "custom/valory/superforcaster/0.1.0": "bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna",
-        "agent/valory/mech_agents_fun/0.1.0": "bafybeicmnmccgylxmyjlh6har426ztrdrojcd2gcfws6lufrz75cfdhw4a",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeiert7hbcqpi7a7lceh3eftat2upstuzvqacli5xh47rllzkfm2w3m"
+        "agent/valory/mech_agents_fun/0.1.0": "bafybeifsdbfamirsk5miufiyasyemojjiae6rppeb5tjwe42iu4ksrivwq",
+        "service/valory/mech_agents_fun/0.1.0": "bafybeif5vgsqy7tvzl642zajuemgqjg5prlhz66advpzcdee526dpha65m"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",

--- a/packages/valory/agents/mech_agents_fun/aea-config.yaml
+++ b/packages/valory/agents/mech_agents_fun/aea-config.yaml
@@ -50,7 +50,7 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m
 customs:
-- agents_fun/google_image_gen:0.1.0:bafybeibkts5sjnrxysabqjznay3bm6hj5hzfvwopvwvb2nbjxjv2ow6rmu
+- agents_fun/google_image_gen:0.1.0:bafybeigh3ekuttzvxi6otzxu2c6yzkliysluqk63gluwl7igz4dpuvyxx4
 - agents_fun/short_maker:0.1.0:bafybeialdibotrsz7l64346iwgczuaqhk3y7ge6ozyzadpgxvhswz7gwpa
 - agents_fun/stability_ai_request:0.1.0:bafybeihndmvigf7vufvwbg24mbdhgbqqlrbuanr6sm5qtoavvmbautsd3e
 - valory/superforcaster:0.1.0:bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech_agents_fun:0.1.0:bafybeicmnmccgylxmyjlh6har426ztrdrojcd2gcfws6lufrz75cfdhw4a
+agent: valory/mech_agents_fun:0.1.0:bafybeifsdbfamirsk5miufiyasyemojjiae6rppeb5tjwe42iu4ksrivwq
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Why

agent-deployments PR#328's Hash checks CI job failed with \`Could not resolve ALLOWED_TOOLS for 1 tool(s): google_image_gen\`. That's because \`verify_tool_hashes.py\` parses each custom package's \`ALLOWED_TOOLS\` constant to verify the tool routing table, and my stubbing pass in #58 stripped it.

## What

Adds \`ALLOWED_TOOLS = ["google_image_gen"]\` (and equivalent for \`google_video_gen\`) back onto both stubs. \`run()\` itself continues to raise \`NotImplementedError("google-genai removed")\`, so runtime behaviour is unchanged; only the metadata-parsing check gets what it needs.

Regenerates the affected agent + service hashes.

## Impact on agent-deployments PR#328

New tool hashes:
- google_image_gen: \`bafybeigh3ekuttzvxi6otzxu2c6yzkliysluqk63gluwl7igz4dpuvyxx4\`
- google_video_gen: \`bafybeidzjajkqaff2pnrpd4gq3kgk2l7jwfpyamypvxjnuhm2s7wfscnla\`

New service hash: \`bafybeif5vgsqy7tvzl642zajuemgqjg5prlhz66advpzcdee526dpha65m\`

agent-deployments PR#328 will need a follow-up commit to point base_mech's TOOLS_TO_PACKAGE_HASH.google_image_gen at the new hash, and PROPEL_SERVICE_HASH_ID at the new service hash, once a mech-agents-fun release is cut off main.

## Verified locally

- \`autonomy packages lock --check\` — OK
- \`tomte tox -p -e black-check -e isort-check -e flake8 -e mypy\` — OK