### PR TITLE
chore(deps): bump mech v0.34.7 -> v0.34.8

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -6,8 +6,8 @@
         "custom/agents_fun/recraft_image_gen/0.1.0": "bafybeiat4d33kqap7pmrh54ckj5dsdamxbxsyttrgocejqiluitfphyj6e",
         "custom/agents_fun/google_video_gen/0.1.0": "bafybeid5joxmshtizrlflhepnym25gi6totyidywqalictudmwgmwionuy",
         "custom/valory/superforcaster/0.1.0": "bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna",
-        "agent/valory/mech_agents_fun/0.1.0": "bafybeicmnmccgylxmyjlh6har426ztrdrojcd2gcfws6lufrz75cfdhw4a",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeiert7hbcqpi7a7lceh3eftat2upstuzvqacli5xh47rllzkfm2w3m"
+        "agent/valory/mech_agents_fun/0.1.0": "bafybeifhiza4ezzxb4hfmibobmgckgblaymddweatfs5b2hqdcueortj3m",
+        "service/valory/mech_agents_fun/0.1.0": "bafybeibi4njchnku6zvulyrl7qkgtylobbhsxvlmh2hqkgbrov677amnga"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",
@@ -49,8 +49,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiafeyknnrcbnba5vkw42tdmsxk5wt4sey2ohlao4hmjzrqadws6ay",
-        "skill/valory/task_execution/0.1.0": "bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq"
+        "skill/valory/mech_abci/0.1.0": "bafybeidkugsxm66kr6vguonbpt2idh5anqgnc6mvakq452g57fi27t4ere",
+        "skill/valory/task_execution/0.1.0": "bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu"
     }
 }

--- a/packages/valory/agents/mech_agents_fun/aea-config.yaml
+++ b/packages/valory/agents/mech_agents_fun/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
-- valory/mech_abci:0.1.0:bafybeiafeyknnrcbnba5vkw42tdmsxk5wt4sey2ohlao4hmjzrqadws6ay
+- valory/mech_abci:0.1.0:bafybeidkugsxm66kr6vguonbpt2idh5anqgnc6mvakq452g57fi27t4ere
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/task_execution:0.1.0:bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm
-- valory/task_submission_abci:0.1.0:bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq
+- valory/task_execution:0.1.0:bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api
+- valory/task_submission_abci:0.1.0:bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech_agents_fun:0.1.0:bafybeicmnmccgylxmyjlh6har426ztrdrojcd2gcfws6lufrz75cfdhw4a
+agent: valory/mech_agents_fun:0.1.0:bafybeifhiza4ezzxb4hfmibobmgckgblaymddweatfs5b2hqdcueortj3m
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ override-dependencies = [
 # author so canonical env vars resolve sensibly.
 packages_paths = "packages/valory"
 # Third-party skills/contracts on disk are synced from mech upstream.
-upstream_pins = ["valory-xyz/mech@v0.34.7"]
+upstream_pins = ["valory-xyz/mech@v0.34.8"]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"
 # Customs are file-form (no per-pkg tests/ dir). The only first-party
 # tests live under tests/; without pinning, auto-discovery picks up


### PR DESCRIPTION
## Summary

Pins upstream mech to [v0.34.8](https://github.com/valory-xyz/mech/releases/tag/v0.34.8).

Three third-party skill hashes bumped (\`mech_abci\`, \`task_execution\`, \`task_submission_abci\`); \`autonomy packages lock\` cascaded the \`mech_agents_fun\` agent and service hashes.

## Verified locally

- \`autonomy packages lock --check\` — OK