### PR TITLE
fix(service): default kv_store store_path so KvStoreConnection can boot

### DIFF
--- a/packages/agents_fun/customs/google_image_gen/component.yaml
+++ b/packages/agents_fun/customs/google_image_gen/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeidnpzfuhbztaogflzlzwi7g7oyt2t5pcx6ayl5xuuixsq2nbt3vcu
-  google_image_gen.py: bafybeicbc5bfbh6ov2o7h45tffut274kupi7go46g5rppx42cgtf4ac2ci
+  google_image_gen.py: bafybeigevajo3pyzwr2syowzalfb54gwdr57hlrdtse77zljvrljkjcewy
 fingerprint_ignore_patterns: []
 entry_point: google_image_gen.py
 callable: run

--- a/packages/agents_fun/customs/google_image_gen/google_image_gen.py
+++ b/packages/agents_fun/customs/google_image_gen/google_image_gen.py
@@ -22,6 +22,8 @@ from typing import Any, Dict, Optional, Tuple
 
 MechResponse = Tuple[str, Optional[str], Optional[Dict[str, Any]], Any, Any]
 
+ALLOWED_TOOLS = ["google_image_gen"]
+
 
 def run(**kwargs: Any) -> MechResponse:
     """Stubbed out: google-genai removed."""

--- a/packages/agents_fun/customs/google_video_gen/component.yaml
+++ b/packages/agents_fun/customs/google_video_gen/component.yaml
@@ -6,7 +6,7 @@ description: A tool to generate shortvideos from text using Google Generative AI
 license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
-  google_video_gen.py: bafybeih3u6f2znqzjqus6utg7zognsle6bayuwxprta3tvf6a2qesr42t4
+  google_video_gen.py: bafybeiholgy3nxptav6pumetnbnewiceqznjpiomdsgaxlhwdx7vowyepq
 fingerprint_ignore_patterns: []
 entry_point: google_video_gen.py
 callable: run

--- a/packages/agents_fun/customs/google_video_gen/google_video_gen.py
+++ b/packages/agents_fun/customs/google_video_gen/google_video_gen.py
@@ -22,6 +22,8 @@ from typing import Any, Dict, Optional, Tuple
 
 MechResponse = Tuple[str, Optional[str], Optional[Dict[str, Any]], Any, Any]
 
+ALLOWED_TOOLS = ["google_video_gen"]
+
 
 def run(**kwargs: Any) -> MechResponse:
     """Stubbed out: google-genai removed."""

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,7 +7,7 @@
         "custom/agents_fun/google_video_gen/0.1.0": "bafybeid5joxmshtizrlflhepnym25gi6totyidywqalictudmwgmwionuy",
         "custom/valory/superforcaster/0.1.0": "bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna",
         "agent/valory/mech_agents_fun/0.1.0": "bafybeifhiza4ezzxb4hfmibobmgckgblaymddweatfs5b2hqdcueortj3m",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeibi4njchnku6zvulyrl7qkgtylobbhsxvlmh2hqkgbrov677amnga"
+        "service/valory/mech_agents_fun/0.1.0": "bafybeiahqcqct5frituess3yrxssnctnlxxdhgp6o2x5c3pcs4fauymb44"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,12 +2,12 @@
     "dev": {
         "custom/agents_fun/short_maker/0.1.0": "bafybeialdibotrsz7l64346iwgczuaqhk3y7ge6ozyzadpgxvhswz7gwpa",
         "custom/agents_fun/stability_ai_request/0.1.0": "bafybeihndmvigf7vufvwbg24mbdhgbqqlrbuanr6sm5qtoavvmbautsd3e",
-        "custom/agents_fun/google_image_gen/0.1.0": "bafybeibkts5sjnrxysabqjznay3bm6hj5hzfvwopvwvb2nbjxjv2ow6rmu",
+        "custom/agents_fun/google_image_gen/0.1.0": "bafybeigh3ekuttzvxi6otzxu2c6yzkliysluqk63gluwl7igz4dpuvyxx4",
         "custom/agents_fun/recraft_image_gen/0.1.0": "bafybeiat4d33kqap7pmrh54ckj5dsdamxbxsyttrgocejqiluitfphyj6e",
-        "custom/agents_fun/google_video_gen/0.1.0": "bafybeid5joxmshtizrlflhepnym25gi6totyidywqalictudmwgmwionuy",
+        "custom/agents_fun/google_video_gen/0.1.0": "bafybeidzjajkqaff2pnrpd4gq3kgk2l7jwfpyamypvxjnuhm2s7wfscnla",
         "custom/valory/superforcaster/0.1.0": "bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna",
-        "agent/valory/mech_agents_fun/0.1.0": "bafybeifhiza4ezzxb4hfmibobmgckgblaymddweatfs5b2hqdcueortj3m",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeiahqcqct5frituess3yrxssnctnlxxdhgp6o2x5c3pcs4fauymb44"
+        "agent/valory/mech_agents_fun/0.1.0": "bafybeih7xgstkns5lpfbmxmh4y5iqkuw6klzqza3gf3wyxvgsci4wx22g4",
+        "service/valory/mech_agents_fun/0.1.0": "bafybeibzcsi7tj6wb44z76ntkcr3oq5xlrz7gy7imh33jk2wlq5tmf63oe"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",

--- a/packages/valory/agents/mech_agents_fun/aea-config.yaml
+++ b/packages/valory/agents/mech_agents_fun/aea-config.yaml
@@ -50,7 +50,7 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m
 customs:
-- agents_fun/google_image_gen:0.1.0:bafybeibkts5sjnrxysabqjznay3bm6hj5hzfvwopvwvb2nbjxjv2ow6rmu
+- agents_fun/google_image_gen:0.1.0:bafybeigh3ekuttzvxi6otzxu2c6yzkliysluqk63gluwl7igz4dpuvyxx4
 - agents_fun/short_maker:0.1.0:bafybeialdibotrsz7l64346iwgczuaqhk3y7ge6ozyzadpgxvhswz7gwpa
 - agents_fun/stability_ai_request:0.1.0:bafybeihndmvigf7vufvwbg24mbdhgbqqlrbuanr6sm5qtoavvmbautsd3e
 - valory/superforcaster:0.1.0:bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech_agents_fun:0.1.0:bafybeifhiza4ezzxb4hfmibobmgckgblaymddweatfs5b2hqdcueortj3m
+agent: valory/mech_agents_fun:0.1.0:bafybeih7xgstkns5lpfbmxmh4y5iqkuw6klzqza3gf3wyxvgsci4wx22g4
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -414,3 +414,8 @@ type: skill
     params:
       args:
         use_polling: ${USE_POLLING:str:false}
+---
+public_id: valory/kv_store:0.1.0
+type: connection
+config:
+  store_path: ${STORE_PATH:str:/data}


### PR DESCRIPTION
## Why

base_mech (v0.3.6) crashes at boot with:

\`\`\`
Error: An error occurred during instantiation of connection valory/kv_store:0.1.0/KvStoreConnection:
TypeError: expected str, bytes or os.PathLike object, not NoneType
  File \"/usr/local/lib/python3.11/pathlib.py\", line 493, in _parse_args
    a = os.fspath(a)
\`\`\`

Observed 10 boot cycles in one 16-minute window on the live deployment — agent restarts in a loop, never reaches tool execution, no requests get settled.

## Root cause

Upstream \`mech\` ships \`packages/valory/connections/kv_store/connection.yaml\` with \`store_path: null\` as the default. \`task_execution\` skill declares \`kv_store\` as a dep, so the connection is loaded into any mech agent that uses task_execution. At boot the connection calls \`os.fspath(store_path)\` and raises on \`None\`.

\`mech-predict/service.yaml\` overrides this with:
\`\`\`yaml
public_id: valory/kv_store:0.1.0
type: connection
config:
  store_path: \${STORE_PATH:str:/data}
\`\`\`

...which is why mech-predict deploys are fine. \`mech-agents-fun/service.yaml\` had no such override.

## What

Adds the same override block to mech-agents-fun's service.yaml. \`STORE_PATH\` is env-overridable at deploy time; default \`/data\` matches mech-predict.

Regenerates the service hash.

## Verified locally

- \`autonomy packages lock --check\` — OK