### PR TITLE
fix(deps): bump open-autonomy 0.21.27 + restore google-genai + kv_store agent-level override

### DIFF
--- a/packages/agents_fun/customs/google_image_gen/component.yaml
+++ b/packages/agents_fun/customs/google_image_gen/component.yaml
@@ -7,10 +7,21 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeidnpzfuhbztaogflzlzwi7g7oyt2t5pcx6ayl5xuuixsq2nbt3vcu
-  google_image_gen.py: bafybeigevajo3pyzwr2syowzalfb54gwdr57hlrdtse77zljvrljkjcewy
+  google_image_gen.py: bafybeidq5gcur2fdmsuw44v6dcy56cxnkbtrrmxvpvr6afw5x6yryp2n4y
 fingerprint_ignore_patterns: []
 entry_point: google_image_gen.py
 callable: run
 params:
   default_model: imagen-4.0-generate-001
-dependencies: {}
+dependencies:
+  google-genai:
+    version: ==1.17.0
+  google-api-core: {}
+  pillow:
+    version: ==12.2.0
+  open-aea-cli-ipfs:
+    version: ==2.2.9
+  anthropic:
+    version: ==0.21.3
+  openai:
+    version: ==1.82.0

--- a/packages/agents_fun/customs/google_image_gen/google_image_gen.py
+++ b/packages/agents_fun/customs/google_image_gen/google_image_gen.py
@@ -16,15 +16,236 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-"""google_image_gen tool. Stubbed: google-genai removed."""
+"""This module contains the implementation of the google_image_gen tool based on a working snippet."""
 
-from typing import Any, Dict, Optional, Tuple
+import functools
+import json
+import os
+from io import BytesIO
+from typing import Any, Callable, Dict, Optional, Tuple
 
+import anthropic
+import openai
+from PIL import Image  # type: ignore[import-not-found]
+from aea_cli_ipfs.ipfs_utils import IPFSTool
+from google import genai  # type: ignore[import-not-found]
+from google.api_core import (
+    exceptions as google_exceptions,  # type: ignore[import-not-found]
+)
+from google.genai import types  # type: ignore[import-not-found]
+
+# Define MechResponse type alias matching the other tools
 MechResponse = Tuple[str, Optional[str], Optional[Dict[str, Any]], Any, Any]
 
-ALLOWED_TOOLS = ["google_image_gen"]
+DEFAULT_MODEL = "imagen-4.0-generate-001"
+
+# Define allowed tools for this module
+ALLOWED_TOOLS = [
+    "google_image_gen",
+]
 
 
-def run(**kwargs: Any) -> MechResponse:
-    """Stubbed out: google-genai removed."""
-    raise NotImplementedError("google-genai removed")
+def with_key_rotation(func: Callable) -> Callable[..., MechResponse]:
+    """Decorator for handling API key rotation and retries."""
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> MechResponse:
+        api_keys = kwargs["api_keys"]
+        # Ensure api_keys object has the expected methods
+        if (
+            not hasattr(api_keys, "max_retries")
+            or not hasattr(api_keys, "rotate")
+            or not hasattr(api_keys, "get")
+        ):
+            error_msg = "api_keys object does not have required methods (max_retries, rotate, get)"
+            prompt_val = kwargs.get("prompt", "N/A")
+            callback_val = kwargs.get("counter_callback", None)
+            return error_msg, prompt_val, None, callback_val, None  # Return 5 elements
+
+        retries_left: Dict[str, int] = api_keys.max_retries()
+
+        def execute() -> MechResponse:
+            """Execute the function with retries."""
+            try:
+                result = func(*args, **kwargs)
+                return result + (api_keys,)
+            except (
+                anthropic.RateLimitError,
+                openai.RateLimitError,
+                google_exceptions.ResourceExhausted,
+                google_exceptions.TooManyRequests,
+            ) as e:
+                service = "google_api_key"
+                if isinstance(e, anthropic.RateLimitError):
+                    service = "anthropic"
+                elif isinstance(e, openai.RateLimitError):
+                    if retries_left["openai"] <= 0 and retries_left["openrouter"] <= 0:
+                        raise e
+                    retries_left["openai"] -= 1
+                    retries_left["openrouter"] -= 1
+                    api_keys.rotate("openai")
+                    api_keys.rotate("openrouter")
+                    return execute()
+
+                if retries_left.get(service, 0) <= 0:
+                    print(f"No retries left for service: {service}")
+                    raise e
+
+                retries_left[service] -= 1
+                print(
+                    f"Rate limit error for {service}. Retries left: {retries_left[service]}. Rotating key."
+                )
+                api_keys.rotate(service)
+                return execute()
+            except (
+                google_exceptions.GoogleAPIError
+            ) as e:  # Specific catch for other GoogleAPIErrors
+                # If not a 500 error, or no code attribute, re-raise immediately
+                if not hasattr(e, "code") or e.code != 500:  # pylint: disable=no-member
+                    raise e
+                service = "google_api_key"
+                # If no retries left for this service, raise.
+                if retries_left.get(service, 0) <= 0:
+                    raise e
+
+                # Retries are available, proceed with retry logic.
+                retries_left[service] -= 1
+                api_keys.rotate(service)
+                return execute()
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                print(f"An unexpected error occurred: {e}")
+                error_response = str(e)
+                prompt_value = kwargs.get(
+                    "prompt", "Prompt not available in error context"
+                )
+                callback_value = kwargs.get("counter_callback", None)
+                return error_response, prompt_value, None, callback_value, api_keys
+
+        return execute()
+
+    return wrapper
+
+
+def _validate_inputs(
+    tool: Optional[str], api_key: Optional[str], prompt: str, counter_callback: Any
+) -> Optional[Tuple[str, str, None, Any]]:
+    """Validate tool and API key."""
+    if tool not in ALLOWED_TOOLS:
+        return (
+            f"Tool {tool} is not supported by this agent.",
+            prompt,
+            None,
+            counter_callback,
+        )
+
+    if not api_key:
+        return (
+            "Google API key (GEMINI_API_KEY) not provided.",
+            prompt,
+            None,
+            counter_callback,
+        )
+    return None
+
+
+def _generate_image_from_google_api(
+    client: genai.Client, prompt: str, model_name: Optional[str], counter_callback: Any
+) -> Tuple[Optional[bytes], Optional[Tuple[str, str, None, Any]]]:
+    """Generates image data using the Google API and handles initial response validation."""
+    response = client.models.generate_images(
+        model=model_name,  # type: ignore[arg-type]
+        prompt=prompt,
+        config=types.GenerateImagesConfig(number_of_images=1),
+    )
+
+    if not response.generated_images:
+        return None, (
+            "No image data found in the response (generated_images is empty).",
+            prompt,
+            None,
+            counter_callback,
+        )
+
+    first_generated_image = response.generated_images[0]
+
+    if not hasattr(first_generated_image, "image") or not hasattr(
+        first_generated_image.image, "image_bytes"
+    ):
+        return None, (
+            "Image data structure is not as expected.",
+            prompt,
+            None,
+            counter_callback,
+        )
+    return first_generated_image.image.image_bytes, None  # type: ignore[union-attr]
+
+
+def _save_image_and_upload_to_ipfs(
+    image_data: bytes, prompt: str, model_name: Optional[str], counter_callback: Any
+) -> Tuple[str, Optional[str], Optional[Dict[str, Any]], Any]:
+    """Saves the image data to a temporary file, uploads to IPFS, and cleans up."""
+    temp_image_path = f"temp_generated_image_{os.getpid()}.png"
+    try:
+        image = Image.open(BytesIO(image_data), formats=("PNG", "JPEG", "WEBP"))
+        image.save(temp_image_path)
+
+        ipfs_tool = IPFSTool()
+        _, image_hash, _ = ipfs_tool.add(temp_image_path, wrap_with_directory=False)
+
+        result_data = {"image_hash": image_hash, "prompt": prompt, "model": model_name}
+        return json.dumps(result_data), prompt, None, counter_callback
+    except FileNotFoundError:
+        return (
+            "IPFS tool not found or not configured correctly.",
+            prompt,
+            None,
+            counter_callback,
+        )
+    finally:
+        if os.path.exists(temp_image_path):
+            os.remove(temp_image_path)
+
+
+@with_key_rotation
+def run(**kwargs: Any) -> Tuple[str, Optional[str], Optional[Dict[str, Any]], Any]:
+    """Runs the Google image generation task using genai.Client."""
+    prompt = kwargs["prompt"]
+    api_keys = kwargs["api_keys"]
+    api_key = api_keys.get("gemini_api_key", None)
+    tool = kwargs.get("tool")
+    counter_callback = kwargs.get("counter_callback", None)
+    model_name = kwargs.get("model") or DEFAULT_MODEL
+
+    validation_error = _validate_inputs(tool, api_key, prompt, counter_callback)
+    if validation_error:
+        return validation_error
+
+    try:
+        client = genai.Client(api_key=api_key)
+
+        image_data, error_response = _generate_image_from_google_api(
+            client, prompt, model_name, counter_callback
+        )
+        if error_response:
+            return error_response
+
+        if (
+            image_data is None
+        ):  # Should not happen if error_response is None, but as a safeguard
+            return (
+                "Failed to generate image data without specific error.",
+                prompt,
+                None,
+                counter_callback,
+            )
+
+        return _save_image_and_upload_to_ipfs(
+            image_data, prompt, model_name, counter_callback
+        )
+
+    except google_exceptions.GoogleAPIError as e:
+        print(f"Google API error: {e}")
+        return f"Google API error: {e}", prompt, None, counter_callback
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"An unexpected error occurred: {e}")
+        return f"An error occurred: {e}", prompt, None, counter_callback

--- a/packages/agents_fun/customs/google_video_gen/component.yaml
+++ b/packages/agents_fun/customs/google_video_gen/component.yaml
@@ -6,8 +6,23 @@ description: A tool to generate shortvideos from text using Google Generative AI
 license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
-  google_video_gen.py: bafybeiholgy3nxptav6pumetnbnewiceqznjpiomdsgaxlhwdx7vowyepq
+  google_video_gen.py: bafybeiclrxsasyh5fnhyvlvyshmsm6byqaeqv2iassler3dqbsf3ohvhle
 fingerprint_ignore_patterns: []
 entry_point: google_video_gen.py
 callable: run
-dependencies: {}
+dependencies:
+  google-genai:
+    version: ==1.17.0
+  google-api-core: {}
+  pillow:
+    version: ==12.2.0
+  open-aea-cli-ipfs:
+    version: ==2.2.9
+  anthropic:
+    version: ==0.21.3
+  openai:
+    version: ==1.82.0
+  requests:
+    version: <2.33.0,>=2.28.1
+  moviepy:
+    version: ==1.0.3

--- a/packages/agents_fun/customs/google_video_gen/google_video_gen.py
+++ b/packages/agents_fun/customs/google_video_gen/google_video_gen.py
@@ -16,15 +16,522 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-"""google_video_gen tool. Stubbed: google-genai removed."""
+"""This module contains the implementation of the google_video_gen tool."""
 
-from typing import Any, Dict, Optional, Tuple
+import functools
+import json
+import logging
+import math
+import os
+import re
+import time
+import wave
+from typing import Any, Callable, Dict, Optional, Tuple
 
+import anthropic
+import requests
+from aea_cli_ipfs.ipfs_utils import IPFSTool
+from google import genai  # type: ignore[import-not-found]
+from google.api_core import (
+    exceptions as google_exceptions,  # type: ignore[import-not-found]
+)
+from google.genai import types  # type: ignore[import-not-found]
+from moviepy.audio.AudioClip import AudioClip, concatenate_audioclips
+from moviepy.audio.fx.audio_fadeout import audio_fadeout
+from moviepy.editor import AudioFileClip, ColorClip, CompositeAudioClip, VideoFileClip
+from moviepy.video.compositing.concatenate import concatenate_videoclips
+
+# Define MechResponse type alias matching the other tools
 MechResponse = Tuple[str, Optional[str], Optional[Dict[str, Any]], Any, Any]
 
-ALLOWED_TOOLS = ["google_video_gen"]
+SYSTEM_INSTRUCTION_CONTENT = (
+    f'Based on the USER INPUT: "{0}", please provide a short voiceover script and a choice of voice for the voiceover. Format your response as plain text with two lines: "Voiceover: [script]" and "Voice: [voice_name]". Each field should contain the respective content as described below.\n\n'
+    '- For the "Voiceover": Use the user input to create a short script no longer than 10 seconds long (around 15-30 words), which has a mindblowing insight. The script should be in direct speech format suitable for text-to-speech AI without any stage directions. Do not just repeat the user input\n\n'
+    "- For the \"Voice\": Choose what type of voice would suit the video from the following available Google TTS voices: 'achernar', 'achird', 'algenib', 'algieba', 'alnilam', 'aoede', 'autonoe', 'callirrhoe', 'charon', 'despina', 'enceladus', 'erinome', 'fenrir', 'gacrux', 'iapetus', 'kore', 'laomedeia', 'leda', 'orus', 'puck', 'pulcherrima', 'rasalgethi', 'sadachbia', 'sadaltager', 'schedar', 'sulafat', 'umbriel', 'vindemiatrix', 'zephyr', 'zubenelgenubi'. Only output the name, nothing else. \n\n"
+    "Please structure your response in the following plain text format:\n\n"
+    "Voiceover: [Insert narrative script here]\n"
+    "Voice: [Insert name of voice here]\n\n"
+    "EXAMPLE USER INPUT:\n"
+    'This is an example desired response for the user input: "Elon Musk flying to mars"\n\n'
+    "Voiceover: In the vast expanse of space, Elon Musk propels towards Mars, not just traversing distance, but also the boundaries of human ambition. This journey symbolizes a leap into the unknown, igniting dreams of interplanetary existence.\n"
+    "Voice: Kore"
+)
 
 
-def run(**kwargs: Any) -> MechResponse:
-    """Stubbed out: google-genai removed."""
-    raise NotImplementedError("google-genai removed")
+# Define allowed tools for this module
+ALLOWED_TOOLS = [
+    "google_video_gen",
+]
+
+
+def with_key_rotation(func: Callable) -> Callable[..., MechResponse]:
+    """Decorator for handling API key rotation and retries."""
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> MechResponse:
+        api_keys = kwargs["api_keys"]
+        # Ensure api_keys object has the expected methods
+        if (
+            not hasattr(api_keys, "max_retries")
+            or not hasattr(api_keys, "rotate")
+            or not hasattr(api_keys, "get")
+        ):
+            error_msg = "api_keys object does not have required methods (max_retries, rotate, get)"
+            prompt_val = kwargs.get("prompt", "N/A")
+            callback_val = kwargs.get("counter_callback", None)
+            return error_msg, prompt_val, None, callback_val, None  # Return 5 elements
+
+        retries_left: Dict[str, int] = api_keys.max_retries()
+
+        def execute() -> MechResponse:
+            """Execute the function with retries."""
+            try:
+                result = func(*args, **kwargs)
+                return result + (api_keys,)
+            except (
+                anthropic.RateLimitError,
+                google_exceptions.ResourceExhausted,
+                google_exceptions.TooManyRequests,
+            ) as e:
+                service = "google_api_key"
+                if isinstance(e, anthropic.RateLimitError):
+                    service = "anthropic"
+                if retries_left.get(service, 0) <= 0:
+                    print(f"No retries left for service: {service}")
+                    raise e
+
+                retries_left[service] -= 1
+                print(
+                    f"Rate limit error for {service}. Retries left: {retries_left[service]}. Rotating key."
+                )
+                api_keys.rotate(service)
+                return execute()
+            except (
+                google_exceptions.GoogleAPIError
+            ) as e:  # Specific catch for other GoogleAPIErrors
+                # If not a 500 error, or no code attribute, re-raise immediately
+                if not hasattr(e, "code") or e.code != 500:  # pylint: disable=no-member
+                    raise e
+                service = "google_api_key"
+                # If no retries left for this service, raise.
+                if retries_left.get(service, 0) <= 0:
+                    raise e
+
+                # Retries are available, proceed with retry logic.
+                retries_left[service] -= 1
+                api_keys.rotate(service)
+                return execute()
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                print(f"An unexpected error occurred: {e}")
+                error_response = str(e)
+                prompt_value = kwargs.get(
+                    "prompt", "Prompt not available in error context"
+                )
+                callback_value = kwargs.get("counter_callback", None)
+                return error_response, prompt_value, None, callback_value, api_keys
+
+        return execute()
+
+    return wrapper
+
+
+def _validate_inputs(
+    tool: Optional[str], api_key: Optional[str], prompt: str, counter_callback: Any
+) -> Optional[Tuple[str, str, None, Any]]:
+    """Validate tool and API key."""
+    if tool not in ALLOWED_TOOLS:
+        return (
+            f"Tool {tool} is not supported by this agent.",
+            prompt,
+            None,
+            counter_callback,
+        )
+
+    if not api_key:
+        return (
+            "Google API key (GEMINI_API_KEY) not provided.",
+            prompt,
+            None,
+            counter_callback,
+        )
+    return None
+
+
+def download_file(url: str, local_filename: str) -> str:
+    """Utility function to download a file from a URL to a local path."""
+    with requests.get(url, stream=True, timeout=60) as r:
+        r.raise_for_status()
+        with open(local_filename, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                f.write(chunk)
+    return local_filename
+
+
+def wave_file(
+    filename: str,
+    pcm: bytes,
+    channels: int = 1,
+    rate: int = 24000,
+    sample_width: int = 2,
+) -> None:
+    """Write PCM audio data to a WAV file."""
+    with wave.open(filename, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(sample_width)
+        wf.setframerate(rate)
+        wf.writeframes(pcm)
+
+
+def _generate_text_with_gemini_flash(
+    client: genai.Client,
+    prompt: str,
+    model_name: str = "gemini-2.0-flash",
+) -> str:
+    """Generates text content using the Google GenAI Flash model."""
+    config = types.GenerateContentConfig(max_output_tokens=500, temperature=0.1)
+    print("requesting google TTS with prompt: ", prompt)
+
+    response = client.models.generate_content(
+        model=model_name, contents=prompt, config=config
+    )
+    text = response.text
+    print("Raw response from _generate_text_with_gemini_flash: \n", text)
+    assert text is not None, "Response text is None"
+    return text
+
+
+def get_audio_prompts(user_input: str, google_client: genai.Client) -> Dict[str, Any]:
+    """Construct the message that includes the user input and uses Google GenAI Flash for generation."""
+    # Combine system instruction and user input into a single prompt for `contents`
+    full_prompt = (
+        SYSTEM_INSTRUCTION_CONTENT.format(user_input)
+        + "\nNow, generate the audio prompts based on the user input."
+    )
+
+    try:
+        raw_content = _generate_text_with_gemini_flash(
+            google_client,
+            prompt=full_prompt,
+        )
+        print("Raw content from _generate_text_with_gemini_flash: \n", raw_content)
+        content = raw_content.strip()
+        print("Stripped content: \n", content)
+
+        # Parse the plain text content to extract voiceover script and voice
+        voiceover_script_match = re.search(r"Voiceover: (.*)", content, re.IGNORECASE)
+        voice_match = re.search(r"Voice: (.*)", content, re.IGNORECASE)
+
+        voiceover_script = (
+            voiceover_script_match.group(1).strip() if voiceover_script_match else ""
+        )
+        voice = (
+            voice_match.group(1).strip() if voice_match else "Kore"
+        )  # Default to Kore if not found
+
+        ALLOWED_VOICES = [
+            "achernar",
+            "achird",
+            "algenib",
+            "algieba",
+            "alnilam",
+            "aoede",
+            "autonoe",
+            "callirrhoe",
+            "charon",
+            "despina",
+            "enceladus",
+            "erinome",
+            "fenrir",
+            "gacrux",
+            "iapetus",
+            "kore",
+            "laomedeia",
+            "leda",
+            "orus",
+            "puck",
+            "pulcherrima",
+            "rasalgethi",
+            "sadachbia",
+            "sadaltager",
+            "schedar",
+            "sulafat",
+            "umbriel",
+            "vindemiatrix",
+            "zephyr",
+            "zubenelgenubi",
+        ]
+        if voice not in ALLOWED_VOICES:
+            logging.warning(
+                f"Requested voice '{voice}' is not allowed. Defaulting to 'Kore'."
+            )
+            voice = "Kore"
+
+        if not voiceover_script:
+            raise ValueError("Could not extract voiceover script from model response.")
+
+        json_object = {"voiceover_script": voiceover_script, "voice": voice}
+
+        print("Audio prompts from Google GenAI Flash for TTS: ", json_object)
+        return json_object
+
+    except Exception as e:
+        logging.error(
+            "Failed to get a response from Google GenAI Flash for audio prompts: %s", e
+        )
+        raise
+
+
+def get_audio_duration(audio_file_path: str) -> int:
+    """Get the duration of an audio file in seconds, rounded up."""
+    if not os.path.exists(audio_file_path):
+        raise FileNotFoundError(f"The audio file {audio_file_path} does not exist.")
+
+    with AudioFileClip(audio_file_path) as audio_clip:
+        duration_seconds = math.ceil(audio_clip.duration)
+
+    print(f"The audio duration is {duration_seconds}")
+    return duration_seconds
+
+
+def compose_final_video(  # pylint: disable=too-many-positional-arguments,too-many-locals
+    video_path: str,
+    voiceover_path: str,
+    file_prefix: str,
+    voiceover_volume: float = 1.0,
+    soundtrack_volume: float = 0.2,
+    fadeout_duration: float = 1.0,
+) -> str:
+    """Compose the final video."""
+    video_clip = VideoFileClip(video_path)
+
+    # Audio Clips
+    voiceover_clip = AudioFileClip(voiceover_path)
+    voiceover_clip = voiceover_clip.volumex(voiceover_volume)
+
+    def make_silence(_t: float) -> list:  # noqa: E731
+        """Return silent audio frame."""
+        return [0]
+
+    soundtrack_clip = (
+        AudioClip(make_frame=make_silence, duration=video_clip.duration)
+        .set_fps(44100)
+        .volumex(soundtrack_volume)
+    )
+
+    # Determine the longest duration
+    print(f"Original Video Duration: {video_clip.duration}")
+    print(f"Original Voiceover Duration: {voiceover_clip.duration}")
+    print(f"Original Soundtrack Duration: {soundtrack_clip.duration}")
+
+    longest_duration = max(
+        video_clip.duration, voiceover_clip.duration, soundtrack_clip.duration
+    )
+
+    # Extend video clip with a black frame if needed
+    if video_clip.duration < longest_duration:
+        black_clip = ColorClip(
+            size=video_clip.size,
+            color=(0, 0, 0),
+            duration=longest_duration - video_clip.duration,
+        )
+        video_clip = concatenate_videoclips([video_clip, black_clip])
+        print(f"Extended Video Duration: {video_clip.duration}")
+
+    # Extend audio clips with silence if needed
+    if voiceover_clip.duration < longest_duration:
+        silence_duration = longest_duration - voiceover_clip.duration
+        silence_clip = AudioClip(
+            make_frame=make_silence, duration=silence_duration
+        ).set_fps(44100)
+        voiceover_clip = concatenate_audioclips([voiceover_clip, silence_clip])
+        print(f"Extended Voiceover Duration: {voiceover_clip.duration}")
+    if soundtrack_clip.duration < longest_duration:
+        silence_duration = longest_duration - soundtrack_clip.duration
+        silence_clip = AudioClip(
+            make_frame=make_silence, duration=silence_duration
+        ).set_fps(44100)
+        soundtrack_clip = concatenate_audioclips([soundtrack_clip, silence_clip])
+        print(f"Extended Soundtrack Duration: {soundtrack_clip.duration}")
+
+    # Apply fade out to the soundtrack
+    soundtrack_clip = soundtrack_clip.fx(audio_fadeout, fadeout_duration)
+
+    final_audio = CompositeAudioClip([soundtrack_clip, voiceover_clip])
+
+    final_video = video_clip.set_audio(final_audio)
+
+    filename = f"{file_prefix}.mp4"
+    final_video.write_videofile(filename, codec="libx264", audio_codec="aac", fps=24)
+
+    return filename
+
+
+def _generate_video_from_google_api(
+    client: genai.Client, prompt: str, model_name: str, counter_callback: Any
+) -> Tuple[Optional[bytes], Optional[Tuple[str, str, None, Any]]]:
+    """Generates video data using the Google API and handles initial response validation."""
+    operation = client.models.generate_videos(
+        model=model_name,
+        prompt=prompt,
+        config=types.GenerateVideosConfig(
+            person_generation="allow_adult",
+            aspect_ratio="16:9",
+        ),
+    )
+
+    print("Waiting for video generation operation to complete...")
+    while not operation.done:
+        time.sleep(20)
+        print(
+            "Waiting for video generation operation to complete... will check again in 20 seconds"
+        )
+        operation = client.operations.get(operation)
+
+    result = operation.result
+    print(f"Video generation operation result: {result}")
+    if result is None or not result.generated_videos:
+        return None, (
+            "No video data found in the response (generated_videos is empty).",
+            prompt,
+            None,
+            counter_callback,
+        )
+
+    video_file = result.generated_videos[0].video
+    assert video_file is not None, "Video file is None"
+
+    # Download the video content
+    print(f"Downloading video file from URI: {video_file.uri}")
+    client.files.download(file=video_file)
+    video_bytes = video_file.video_bytes
+
+    return video_bytes, None
+
+
+def _save_video_and_upload_to_ipfs(
+    video_data: bytes, prompt: str, model_name: str, counter_callback: Any
+) -> Tuple[str, Optional[str], Optional[Dict[str, Any]], Any, str]:
+    """Saves the video data to a temporary file, uploads to IPFS, and returns the path."""
+    temp_video_path = f"temp_generated_video_{os.getpid()}.mp4"
+    try:
+        with open(temp_video_path, "wb") as f:
+            f.write(video_data)
+
+        ipfs_tool = IPFSTool()
+        _, video_hash, _ = ipfs_tool.add(temp_video_path, wrap_with_directory=False)
+
+        result_data = {"video_hash": video_hash, "prompt": prompt, "model": model_name}
+        # The `temp_video_path` is returned to be used for video merging.
+        return json.dumps(result_data), prompt, None, counter_callback, temp_video_path
+    except FileNotFoundError:
+        return (
+            "IPFS tool not found or not configured correctly.",
+            prompt,
+            None,
+            counter_callback,
+            "",  # Return empty string for temp_video_path on error
+        )
+
+
+def _generate_audio_with_gemini_tts(
+    client: genai.Client, text: str, voice_name: str
+) -> bytes:
+    """Generates audio data using the Google GenAI TTS API."""
+    response = client.models.generate_content(
+        model="gemini-2.5-flash-preview-tts",
+        contents=text,
+        config=types.GenerateContentConfig(
+            response_modalities=["AUDIO"],
+            speech_config=types.SpeechConfig(
+                voice_config=types.VoiceConfig(
+                    prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                        voice_name=voice_name,
+                    )
+                )
+            ),
+        ),
+    )
+    candidates = response.candidates
+    assert candidates is not None, "Response candidates is None"
+    content = candidates[0].content
+    assert content is not None, "Candidate content is None"
+    parts = content.parts
+    assert parts is not None, "Content parts is None"
+    inline_data = parts[0].inline_data
+    assert inline_data is not None, "Inline data is None"
+    data = inline_data.data
+    assert data is not None, "Inline data bytes is None"
+    return data
+
+
+@with_key_rotation
+def run(  # pylint: disable=too-many-locals
+    **kwargs: Any,
+) -> Tuple[str, Optional[str], Optional[Dict[str, Any]], Any]:
+    """Runs the Google video generation task using genai.Client and adds audio."""
+    prompt = kwargs["prompt"]
+    api_keys = kwargs["api_keys"]
+    google_api_key = api_keys.get("gemini_api_key", None)
+    tool = kwargs.get("tool")
+    counter_callback = kwargs.get("counter_callback", None)
+    model_name = "veo-2.0-generate-001"
+
+    # Initialize clients
+    google_client = genai.Client(api_key=google_api_key)
+
+    file_prefix = prompt[:20].replace(" ", "_").replace("-", "_").lower()
+
+    validation_error = _validate_inputs(tool, google_api_key, prompt, counter_callback)
+    if validation_error:
+        return validation_error
+
+    temp_files = []
+    try:
+        # Step 1: Video generation (pending implementation)
+
+        # Step 2: Get audio prompts from OpenAI
+        try:
+            audio_prompts = get_audio_prompts(
+                user_input=prompt, google_client=google_client
+            )
+            voiceover_script = audio_prompts["voiceover_script"]
+            voice_choice = audio_prompts["voice"]
+            print(f"Voiceover Script: {voiceover_script}")
+            print(f"Voice Choice: {voice_choice}")
+
+        except Exception as e:
+            print(f"Error getting audio prompts: {e}")
+            raise
+
+        # Step 3: Process voiceover using Google TTS
+        try:
+            voice_name = voice_choice  # Use the voice chosen by the model
+            audio_bytes = _generate_audio_with_gemini_tts(
+                google_client, voiceover_script, voice_name
+            )
+            voiceover_filename = f"{file_prefix}_voiceover.wav"
+            wave_file(voiceover_filename, audio_bytes)
+            voiceover_path = voiceover_filename  # Path is the filename itself now
+            temp_files.append(voiceover_path)
+        except Exception as e:
+            print(f"Error processing voiceover: {e}")
+            raise
+
+        # Step 4 & 5: Video merging and IPFS upload
+        # Video generation step is pending implementation.
+        ipfs_tool = IPFSTool()
+        _, audio_hash, _ = ipfs_tool.add(voiceover_path, wrap_with_directory=False)
+
+        result_data = {"audio_hash": audio_hash, "prompt": prompt, "model": model_name}
+        return json.dumps(result_data), prompt, None, counter_callback
+
+    except google_exceptions.GoogleAPIError as e:
+        print(f"Google API error: {e}")
+        return f"Google API error: {e}", prompt, None, counter_callback
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"An unexpected error occurred: {e}")
+        return f"An error occurred: {e}", prompt, None, counter_callback
+    finally:
+        for f in temp_files:
+            if os.path.exists(f):
+                os.remove(f)

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -6,8 +6,8 @@
         "custom/agents_fun/recraft_image_gen/0.1.0": "bafybeiat4d33kqap7pmrh54ckj5dsdamxbxsyttrgocejqiluitfphyj6e",
         "custom/agents_fun/google_video_gen/0.1.0": "bafybeidzjajkqaff2pnrpd4gq3kgk2l7jwfpyamypvxjnuhm2s7wfscnla",
         "custom/valory/superforcaster/0.1.0": "bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna",
-        "agent/valory/mech_agents_fun/0.1.0": "bafybeih7xgstkns5lpfbmxmh4y5iqkuw6klzqza3gf3wyxvgsci4wx22g4",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeibzcsi7tj6wb44z76ntkcr3oq5xlrz7gy7imh33jk2wlq5tmf63oe"
+        "agent/valory/mech_agents_fun/0.1.0": "bafybeihs62rzim7hc7hqjc4lv66ogktiymh6q3igzq4opmmye2noybzqwe",
+        "service/valory/mech_agents_fun/0.1.0": "bafybeicqj5inj2tpmyn22u662hrqbox7oaqexidvvlxiyfscue763enbre"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,12 +2,12 @@
     "dev": {
         "custom/agents_fun/short_maker/0.1.0": "bafybeialdibotrsz7l64346iwgczuaqhk3y7ge6ozyzadpgxvhswz7gwpa",
         "custom/agents_fun/stability_ai_request/0.1.0": "bafybeihndmvigf7vufvwbg24mbdhgbqqlrbuanr6sm5qtoavvmbautsd3e",
-        "custom/agents_fun/google_image_gen/0.1.0": "bafybeigh3ekuttzvxi6otzxu2c6yzkliysluqk63gluwl7igz4dpuvyxx4",
+        "custom/agents_fun/google_image_gen/0.1.0": "bafybeiczdxwwottbwphberpnrlv6abp3g4ccin265qnkkd3j56h3rjvrmi",
         "custom/agents_fun/recraft_image_gen/0.1.0": "bafybeiat4d33kqap7pmrh54ckj5dsdamxbxsyttrgocejqiluitfphyj6e",
-        "custom/agents_fun/google_video_gen/0.1.0": "bafybeidzjajkqaff2pnrpd4gq3kgk2l7jwfpyamypvxjnuhm2s7wfscnla",
+        "custom/agents_fun/google_video_gen/0.1.0": "bafybeifqegajjjjfcxc6yc6jebl3x4dchcxlpw2o5kxxtadtguu2hipy2e",
         "custom/valory/superforcaster/0.1.0": "bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna",
-        "agent/valory/mech_agents_fun/0.1.0": "bafybeihs62rzim7hc7hqjc4lv66ogktiymh6q3igzq4opmmye2noybzqwe",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeicqj5inj2tpmyn22u662hrqbox7oaqexidvvlxiyfscue763enbre"
+        "agent/valory/mech_agents_fun/0.1.0": "bafybeialwz2ymre5v2y263umrud7ovd4up3aila7ha5bvaxqqs4yxrewpa",
+        "service/valory/mech_agents_fun/0.1.0": "bafybeihnuvxjwhfepcdgbnlwey2cjsmcsagxnwjuhkul32hllvxhbzz5ve"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",

--- a/packages/valory/agents/mech_agents_fun/aea-config.yaml
+++ b/packages/valory/agents/mech_agents_fun/aea-config.yaml
@@ -52,7 +52,7 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m
 customs:
-- agents_fun/google_image_gen:0.1.0:bafybeigh3ekuttzvxi6otzxu2c6yzkliysluqk63gluwl7igz4dpuvyxx4
+- agents_fun/google_image_gen:0.1.0:bafybeiczdxwwottbwphberpnrlv6abp3g4ccin265qnkkd3j56h3rjvrmi
 - agents_fun/short_maker:0.1.0:bafybeialdibotrsz7l64346iwgczuaqhk3y7ge6ozyzadpgxvhswz7gwpa
 - agents_fun/stability_ai_request:0.1.0:bafybeihndmvigf7vufvwbg24mbdhgbqqlrbuanr6sm5qtoavvmbautsd3e
 - valory/superforcaster:0.1.0:bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna
@@ -96,8 +96,11 @@ dependencies:
     version: <1.5.0,>=1.4.0
   ecdsa:
     version: '>=0.15'
+  google-api-core: {}
   google-api-python-client:
     version: ==2.130.0
+  google-genai:
+    version: ==1.17.0
   grpcio:
     version: ==1.78.0
   httpx:
@@ -113,7 +116,7 @@ dependencies:
   open-aea-ledger-ethereum:
     version: ==2.2.9
   open-aea-test-autonomy:
-    version: ==0.21.26
+    version: ==0.21.27
   openai:
     version: ==1.82.0
   openapi-core:

--- a/packages/valory/agents/mech_agents_fun/aea-config.yaml
+++ b/packages/valory/agents/mech_agents_fun/aea-config.yaml
@@ -11,6 +11,7 @@ connections:
 - valory/http_client:0.23.0:bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4
 - valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
 - valory/ipfs:0.1.0:bafybeidob3tcdebjbm4ovwqoz4v2egf7nvoui3hu5on4o3apfchr6rpwwa
+- valory/kv_store:0.1.0:bafybeib2tvoui6kndvrd2gpvs55rizpjee7mqjtjsfbr6fdp5hxslh6gd4
 - valory/ledger:0.19.0:bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4
 - valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
 - valory/websocket_client:0.1.0:bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea
@@ -33,6 +34,7 @@ protocols:
 - valory/contract_api:1.0.0:bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
 - valory/ipfs:0.1.0:bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam
+- valory/kv_store:0.1.0:bafybeidlfrgv5rc7m7kj3j6u6umogmpy5bgcdzqtnsy3v75wn3likvyt6m
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 - valory/tendermint:0.1.0:bafybeihzb7e32f7jcrzvubilqaxzmyk7ea6ss3pg3tliatdlrr76qeknyq
 - valory/websocket_client:0.1.0:bafybeig6omutaqt5rbvidju4zc7pwwdi6tkagwu3dwiirosadyoo534v3q
@@ -283,3 +285,8 @@ config:
   target_skill_id: valory/mech_abci:0.1.0
   port: ${int:8000}
 is_abstract: false
+---
+public_id: valory/kv_store:0.1.0
+type: connection
+config:
+  store_path: ${str:/data}

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech_agents_fun:0.1.0:bafybeih7xgstkns5lpfbmxmh4y5iqkuw6klzqza3gf3wyxvgsci4wx22g4
+agent: valory/mech_agents_fun:0.1.0:bafybeihs62rzim7hc7hqjc4lv66ogktiymh6q3igzq4opmmye2noybzqwe
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech_agents_fun:0.1.0:bafybeihs62rzim7hc7hqjc4lv66ogktiymh6q3igzq4opmmye2noybzqwe
+agent: valory/mech_agents_fun:0.1.0:bafybeialwz2ymre5v2y263umrud7ovd4up3aila7ha5bvaxqqs4yxrewpa
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
     # OA / open-aea / plugins — pinned exactly (framework contract).
-    "open-autonomy[all]==0.21.26",
+    "open-autonomy[all]==0.21.27",
     "open-aea-ledger-ethereum==2.2.9",
     "open-aea-ledger-cosmos==2.2.9",
     "open-aea-test-autonomy==0.21.26",
@@ -47,6 +47,8 @@ dependencies = [
     "moviepy==1.0.3",
     "anthropic==0.21.3",
     "google-api-python-client==2.130.0",
+    "google-api-core>=2.20.0,<3",
+    "google-genai==1.17.0",
     "tiktoken==0.12.0",
     "httpx==0.28.1",
     "pydantic>=2.0.0,<3.0.0",
@@ -72,20 +74,14 @@ dev = [
 [tool.uv]
 default-groups = "all"
 prerelease = "allow"
-# OA 0.21.26 has open-aea-ledger-solana 2.2.9 as a direct (non-optional)
-# dep; its solana<0.34 pin conflicts with google-genai's websockets>=13.
-# Solana is never imported (required_ledgers = ethereum + cosmos), so
-# force a solana series with widened websockets. solders bound tracks
-# solana 0.36.x's requires-dist (>=0.23,<0.27).
-# Note: override-dependencies is uv-only. Plain `pip install -e .` will
-# ignore it and re-resolve the conflict. CI uses tox-uv everywhere, but
-# local installs should go through `uv sync`.
+# OA 0.21.27 moved open-aea-ledger-solana behind an optional [solana]
+# extra. We don't declare that extra, so the solana chain (and its
+# solana<0.34 → websockets<12 constraint) never gets pulled. The
+# earlier override-dependencies workaround is no longer needed.
 override-dependencies = [
-    "solana>=0.36.0,<0.37.0",
-    "solders>=0.23,<0.27",
-    # cffi 2.1.0+ (transitive via cryptography << open-aea-ledger-solana)
-    # reports its license as MIT-0, which tomte's PARANOID liccheck rejects.
-    # Constrain to the previous minor until the tomte allowlist covers MIT-0.
+    # cffi 2.1.0+ (transitive via cryptography) reports its license as
+    # MIT-0, which tomte's PARANOID liccheck rejects. Constrain to the
+    # previous minor until the tomte allowlist covers MIT-0.
     "cffi<2.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ dependencies = [
     "open-autonomy[all]==0.21.27",
     "open-aea-ledger-ethereum==2.2.9",
     "open-aea-ledger-cosmos==2.2.9",
-    "open-aea-test-autonomy==0.21.26",
+    "open-aea-test-autonomy==0.21.27",
     "open-aea-cli-ipfs==2.2.9",
-    "open-aea-helpers==0.21.26",
+    "open-aea-helpers==0.21.27",
     # Agent-repo (app) deps — exact pins per David's #436 rule.
     # Ranges are reserved for framework/lib repos; agent repos pin
     # everything non-OA throughout.

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ ignore_missing_imports = True
 
 [Authorized Packages]
 ; open-autonomy wheel metadata reports "Other/Proprietary"; actual license is Apache-2.0.
-open-autonomy: ==0.21.26
+open-autonomy: ==0.21.27
 ; Transitive via solana (forced to >=0.36 by [tool.uv] override-dependencies
 ; so OA's open-aea-ledger-solana plugin doesn't pin websockets<12 against
 ; google-genai's >=13). All three are MIT per upstream repos but expose no

--- a/uv.lock
+++ b/uv.lock
@@ -85,10 +85,10 @@ requires-dist = [
     { name = "moviepy", specifier = "==1.0.3" },
     { name = "multidict", specifier = "==6.7.1" },
     { name = "open-aea-cli-ipfs", specifier = "==2.2.9" },
-    { name = "open-aea-helpers", specifier = "==0.21.26" },
+    { name = "open-aea-helpers", specifier = "==0.21.27" },
     { name = "open-aea-ledger-cosmos", specifier = "==2.2.9" },
     { name = "open-aea-ledger-ethereum", specifier = "==2.2.9" },
-    { name = "open-aea-test-autonomy", specifier = "==0.21.26" },
+    { name = "open-aea-test-autonomy", specifier = "==0.21.27" },
     { name = "open-autonomy", extras = ["all"], specifier = "==0.21.27" },
     { name = "openai", specifier = "==1.82.0" },
     { name = "openapi-core", specifier = "==0.22.0" },
@@ -2379,14 +2379,14 @@ wheels = [
 
 [[package]]
 name = "open-aea-helpers"
-version = "0.21.26"
+version = "0.21.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "open-autonomy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/76/60c31f9757505d84ee14392077eb6f804b0f3150f282a97de58c27f9c3c9/open_aea_helpers-0.21.26.tar.gz", hash = "sha256:c76c328c3147ea6c7318c4968cfa465f987162fd4bc377c43db8f86fd82384dc", size = 41116, upload-time = "2026-07-03T12:36:13.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/7f/603f218974837f700d641b27be9cd2491390315c8d67dfb14bfa83c50673/open_aea_helpers-0.21.27.tar.gz", hash = "sha256:eb82f28c2f320bf97261ac9136030079dd14ff60efee35dda22f54ff6da2f274", size = 41208, upload-time = "2026-08-13T15:12:30.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/a0/993a7abaab4520706fc54d5bfd16164d54aec45d1ccc3efcf5f3deed6a16/open_aea_helpers-0.21.26-py3-none-any.whl", hash = "sha256:f6039f3f0fad3abbcc6862c7d416373e6c6d98e620174b394eba611389d3152e", size = 44415, upload-time = "2026-07-03T12:36:12.861Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/46/0910eef3b00ee804b29203abe0af7cc82eacb95567ac76c05fe09e33adfd/open_aea_helpers-0.21.27-py3-none-any.whl", hash = "sha256:33128c4c1f4bc0013ec3fdb5bbb275139c81791a6688ed3c7f05e15c1adf6e23", size = 44415, upload-time = "2026-08-13T15:12:29.201Z" },
 ]
 
 [[package]]
@@ -2423,14 +2423,14 @@ wheels = [
 
 [[package]]
 name = "open-aea-test-autonomy"
-version = "0.21.26"
+version = "0.21.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "open-autonomy", extra = ["all", "docker"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/fb/98835dbd14be4997885264c9a1e212818b0f3489a97bd4499bb09e511b6d/open_aea_test_autonomy-0.21.26.tar.gz", hash = "sha256:f1547017d4e86428bef14ee116f159d8b96b52e6c2209a8f744e4d07aaaa1bb5", size = 34855, upload-time = "2026-07-03T12:36:09.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ca/0898bf0103cecd70878609e69207f6ebaf790570b4f041d6125410b45eeb/open_aea_test_autonomy-0.21.27.tar.gz", hash = "sha256:35debd02530fdc801d4119ba27ad9059835750799bf1fb687fae3bcd0338578c", size = 34902, upload-time = "2026-08-13T15:12:25.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/45/e7713f9a2a4809a43f6acbd67e9bb434ba181951c07e7907a17b47d23654/open_aea_test_autonomy-0.21.26-py3-none-any.whl", hash = "sha256:771159962ce77a617c96ab312b43cdc680855efc1803f6fe458fe287358943b7", size = 51501, upload-time = "2026-07-03T12:36:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b4/360348f0e5d0e7637c149527bad8bd3b850b151722e101cbef1cc1e2f241/open_aea_test_autonomy-0.21.27-py3-none-any.whl", hash = "sha256:83f8491187e64c3e90eb87b488cbb52e51bc423b3085d27a71f8eb5225a73742", size = 51499, upload-time = "2026-08-13T15:12:24.639Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -13,11 +13,7 @@ resolution-markers = [
 prerelease-mode = "allow"
 
 [manifest]
-overrides = [
-    { name = "cffi", specifier = "<2.1" },
-    { name = "solana", specifier = ">=0.36.0,<0.37.0" },
-    { name = "solders", specifier = ">=0.23,<0.27" },
-]
+overrides = [{ name = "cffi", specifier = "<2.1" }]
 
 [[package]]
 name = "agents-fun"
@@ -30,7 +26,9 @@ dependencies = [
     { name = "certifi" },
     { name = "ecdsa" },
     { name = "eth-utils" },
+    { name = "google-api-core" },
     { name = "google-api-python-client" },
+    { name = "google-genai" },
     { name = "grpcio" },
     { name = "httpx" },
     { name = "hypothesis" },
@@ -77,7 +75,9 @@ requires-dist = [
     { name = "certifi", specifier = "==2026.2.25" },
     { name = "ecdsa", specifier = ">=0.15" },
     { name = "eth-utils", specifier = "==6.0.0" },
+    { name = "google-api-core", specifier = ">=2.20.0,<3" },
     { name = "google-api-python-client", specifier = "==2.130.0" },
+    { name = "google-genai", specifier = "==1.17.0" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "hypothesis", specifier = "==6.21.6" },
@@ -89,7 +89,7 @@ requires-dist = [
     { name = "open-aea-ledger-cosmos", specifier = "==2.2.9" },
     { name = "open-aea-ledger-ethereum", specifier = "==2.2.9" },
     { name = "open-aea-test-autonomy", specifier = "==0.21.26" },
-    { name = "open-autonomy", extras = ["all"], specifier = "==0.21.26" },
+    { name = "open-autonomy", extras = ["all"], specifier = "==0.21.27" },
     { name = "openai", specifier = "==1.82.0" },
     { name = "openapi-core", specifier = "==0.22.0" },
     { name = "openapi-spec-validator", specifier = ">=0.7.0,<0.8.0" },
@@ -259,47 +259,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anchorpy"
-version = "0.20.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anchorpy-core" },
-    { name = "based58" },
-    { name = "borsh-construct" },
-    { name = "construct-typing" },
-    { name = "pyheck" },
-    { name = "solana" },
-    { name = "solders" },
-    { name = "toml" },
-    { name = "toolz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/41/f1/42c63244167e58711af0ddf5abf70af3acd3a41af0f61c6df032d18fd0e9/anchorpy-0.20.2.tar.gz", hash = "sha256:92c89e6dba67a8dd6514173190cda9cb2c8ab10d7cd874003091c201771cb129", size = 646446, upload-time = "2025-03-22T12:45:06.753Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/cd/3ca9ef931c7e05e10f8ad841438aa65a900d7e292320766f78fc5d5e7082/anchorpy-0.20.2-py3-none-any.whl", hash = "sha256:052bfc69eb490de4cbd805f8c122b8270ca16ed086d745b3397836fc489490b9", size = 63165, upload-time = "2025-03-22T12:45:05.322Z" },
-]
-
-[[package]]
-name = "anchorpy-core"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonalias" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/46/17500a3079f587355b33af5af1ee9e8df91c84720a9919a7259ebe2f4d4f/anchorpy_core-0.2.0.tar.gz", hash = "sha256:e06f0b9867d5d773a574b5027d19558a24d738b5c0d73df5ab5a97119c466ce2", size = 27784, upload-time = "2023-12-29T12:53:34.239Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/7d/585844efd6ae37d9c5329239a3a8b090e1a732588f9eeb70a91e0e0377b3/anchorpy_core-0.2.0-cp37-abi3-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:f04928c0916e8a5cba5986a85db682df19e204bb424bdea49b8a46fc45f2fc66", size = 1544885, upload-time = "2023-12-29T12:53:09.405Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/26/2c44a7e0b0f73950c0efff2203d1758004610d3f8ea80f56a8871ed46204/anchorpy_core-0.2.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e37373336fa735f7f3f5eab8f3b090c8a39ef48f3f4f367ad703c7643260560", size = 1849361, upload-time = "2023-12-29T12:53:12.144Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/9b/04b54ccbada11ddc653020059088b933ab0ebc39c4a29418f98df87a152f/anchorpy_core-0.2.0-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:60b5a2b779acbba6b60957fb76a568d6b29c24147c2fff6a127d25842fcbe5a5", size = 1665700, upload-time = "2023-12-29T12:53:14.287Z" },
-    { url = "https://files.pythonhosted.org/packages/03/79/4cdfa0b4b9d87c372b49644dead37fcabd674531508ee7a90820a6cfbe73/anchorpy_core-0.2.0-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:67293b0a1e29df0b50fcac616a5122e3639842f115666f58267470666a847b59", size = 2014217, upload-time = "2023-12-29T12:53:17.204Z" },
-    { url = "https://files.pythonhosted.org/packages/60/7a/642c24da4e8e229d98a2c3938ba296994e04ef5c1d5b742d26a663e47161/anchorpy_core-0.2.0-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abb91b8781cae23113ca03b567973e00c1caf6b341707dbe0fe2ca832af66e5b", size = 2138067, upload-time = "2023-12-29T12:53:19.335Z" },
-    { url = "https://files.pythonhosted.org/packages/77/c5/26c74f8d3eff4711f9035d1a31e7030f1e76912981d1deeaabed749b8f28/anchorpy_core-0.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9fb52db4e37736bf461737b4fc088f3c31ee9d1926d7f52f8432e6f25b38c9b", size = 1858826, upload-time = "2023-12-29T12:53:21.78Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/62/828918bc32542294639fe82f0f005af953635af235e1192a25139a66b452/anchorpy_core-0.2.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c5d70c9992b678a92640981013c1953a6f7d7de383bc837a511bb96534539db8", size = 1917205, upload-time = "2023-12-29T12:53:24.668Z" },
-    { url = "https://files.pythonhosted.org/packages/69/68/89adc5886abc87fa719cc76e5bc08c2fb4f48346b63fbb009aa3d18f55a0/anchorpy_core-0.2.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:41588e343bad3945bf5bbdeeff1c92c6cf8b517590739e100d96fc9505c3bc6f", size = 2159888, upload-time = "2023-12-29T12:53:26.861Z" },
-    { url = "https://files.pythonhosted.org/packages/02/ef/3666c84e46ee2d63bfcc67036bac55440b34c91ae2f12655b6308698b028/anchorpy_core-0.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:af25089ba1fe2a3494536b77d8b93e191cce50ced5afa2fdf7cc83a0d0839750", size = 2138551, upload-time = "2023-12-29T12:53:29.766Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a3/c74871de3844c3cc7acd57a889537b9b83489bd6a2330587f7d861c89c75/anchorpy_core-0.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:9e0d34e2b168855847d0b0c2e33d3c63767a89bb7b78bcb377365b4e6db6aaba", size = 677626, upload-time = "2023-12-29T12:53:32.307Z" },
-]
-
-[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -383,29 +342,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
-]
-
-[[package]]
-name = "based58"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/a9/dbf5ff314d7b7d3b3246e01f2f6cbb880b62c7a958a8520237b982db191a/based58-0.1.1.tar.gz", hash = "sha256:80804b346b34196c89dc7a3dc89b6021f910f4cd75aac41d433ca1880b1672dc", size = 3615, upload-time = "2022-04-24T09:14:50.997Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/1d/10b5d61e11f96cc2f038b06776a9761465b1d020bf0e95e60da23a3a3ba8/based58-0.1.1-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:745851792ce5fada615f05ec61d7f360d19c76950d1e86163b2293c63a5d43bc", size = 251767, upload-time = "2022-04-24T09:14:34.404Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a2/e1436e5ae5a9e117d248017bef101ee99c47549af6ad15bc58b018174202/based58-0.1.1-cp37-abi3-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:f8448a71678bd1edc0a464033695686461ab9d6d0bc3282cb29b94f883583572", size = 492659, upload-time = "2022-04-24T09:14:35.903Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/bc/d6bd738adf98bf4102dfeb33aa7ac58ede12ea924fea89a9751a8ec9c15b/based58-0.1.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:852c37206374a62c5d3ef7f6777746e2ad9106beec4551539e9538633385e613", size = 1016479, upload-time = "2022-04-24T09:14:37.186Z" },
-    { url = "https://files.pythonhosted.org/packages/01/70/ed49e0a541fae6de7ef0858b08fc95ab7223c3f39aa5e30e03bba498f355/based58-0.1.1-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fb17f0aaaad0381c8b676623c870c1a56aca039e2a7c8416e65904d80a415f7", size = 1019631, upload-time = "2022-04-24T09:14:38.797Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/7e/748debfbe5146394893f6f60a77b5fe343a093850340d312e4ddac03190f/based58-0.1.1-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:06f3c40b358b0c6fc6fc614c43bb11ef851b6d04e519ac1eda2833420cb43799", size = 1140341, upload-time = "2022-04-24T09:14:40.202Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ad/ec48ad774b33ff521cec8355e7fb782f3f11761cc4a7342c054faf5fd747/based58-0.1.1-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2a9db744be79c8087eebedbffced00c608b3ed780668ab3c59f1d16e72c84947", size = 1128929, upload-time = "2022-04-24T09:14:41.581Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/bc/9bdba9ef4b2185d12c9ba4028168081ce2359d399087f51415db11073a44/based58-0.1.1-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0506435e98836cc16e095e0d6dc428810e0acfb44bc2f3ac3e23e051a69c0e3e", size = 1182359, upload-time = "2022-04-24T09:14:42.802Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/85/73ef6c410a5525b0a95c84a7e5e0902ce1d690a5f86ef36b0224d333e7b6/based58-0.1.1-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8937e97fa8690164fd11a7c642f6d02df58facd2669ae7355e379ab77c48c924", size = 1045452, upload-time = "2022-04-24T09:14:43.914Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/30/216be65c673259d6227c34690ce35e81858177bc6ad3cffab6699c93e115/based58-0.1.1-cp37-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:14b01d91ac250300ca7f634e5bf70fb2b1b9aaa90cc14357943c7da525a35aff", size = 1020913, upload-time = "2022-04-24T09:14:45.024Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/79/2b77d260e67b7135b050279a9b74fe4d45c4edf63a08cdff2d334fd7f4b6/based58-0.1.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6c03c7f0023981c7d52fc7aad23ed1f3342819358b9b11898d693c9ef4577305", size = 1221614, upload-time = "2022-07-18T08:33:09.514Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/e8/774840132f2c7ded2f377fb22c1c6ddaa2041c4ea4d42d1547bc6758af89/based58-0.1.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:621269732454875510230b85053f462dffe7d7babecc8c553fdb488fd15810ff", size = 1384904, upload-time = "2022-07-18T08:33:11.106Z" },
-    { url = "https://files.pythonhosted.org/packages/58/c1/603af0cf18e7c72f31089cced681b599caa2a011d0ca16cfe2a676e33ceb/based58-0.1.1-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:aba18f6c869fade1d1551fe398a376440771d6ce288c54cba71b7090cf08af02", size = 1226434, upload-time = "2022-04-24T09:14:46.124Z" },
-    { url = "https://files.pythonhosted.org/packages/18/79/ed5278c4ef0dd8ab7695417c132329064ae6f8963f12521cb0b1b6c8e71f/based58-0.1.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ae7f17b67bf0c209da859a6b833504aa3b19dbf423cbd2369aa17e89299dc972", size = 1203980, upload-time = "2022-04-24T09:14:47.498Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/7c/5c7c9e6d1ddd083a4cf25c4182fbaacfa7371ac9e82479c98aa29830bb8b/based58-0.1.1-cp37-abi3-win32.whl", hash = "sha256:d8dece575de525c1ad889d9ab239defb7a6ceffc48f044fe6e14a408fb05bef4", size = 135478, upload-time = "2022-04-24T09:14:48.904Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/13/35a9ee917ef05d734b0aa75400cfff44325594894d8d928d36b4dc0030d1/based58-0.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:ab85804a401a7b5a7141fbb14ef5b5f7d85288357d1d3f0085d47e616cef8f5a", size = 141512, upload-time = "2022-04-24T09:14:49.942Z" },
 ]
 
 [[package]]
@@ -501,19 +437,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a0/fe5dbdfadcba2314551614d023db100e3aea7b09da2cdcbf1386f5c797a6/bitarray-3.8.1-cp314-cp314t-win32.whl", hash = "sha256:cf99e36c0f6ae5643ecef7ad7e1194aeb4a9798d9cff60b20ac041533fa6db0a", size = 144160, upload-time = "2026-04-02T16:28:12.702Z" },
     { url = "https://files.pythonhosted.org/packages/4e/0a/e95ed44f6d89e63ed666755fc0773223b10df0058d5de30d529f4cf35948/bitarray-3.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9befda0dbd27ed95fba1c26be4bf98a49ba166b3c91beb5fc04364c130ce950c", size = 150852, upload-time = "2026-04-02T16:28:14.149Z" },
     { url = "https://files.pythonhosted.org/packages/0f/90/454b88b193743b4cd0fce0819a11b1c43b7f629cb2533f6ddc62cbb5e097/bitarray-3.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:4b7d7d10a1c82050efbb9a83d7a43974f70cf8f021afb86463b42e4ac4e5a46b", size = 147343, upload-time = "2026-04-02T16:28:15.632Z" },
-]
-
-[[package]]
-name = "borsh-construct"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "construct-typing" },
-    { name = "sumtypes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/0c/8062d8d795e7b9518923bfba453f883e2cbf80c5b05de699e4424a523a71/borsh-construct-0.1.0.tar.gz", hash = "sha256:c916758ceba70085d8f456a1cc26991b88cb64233d347767766473b651b37263", size = 5808, upload-time = "2021-10-20T11:16:49.095Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/1d/52c0741626a17eb1a2f554e27dc2883f9bb98bb7b2392f9cbd1f39c36fea/borsh_construct-0.1.0-py3-none-any.whl", hash = "sha256:f584c791e2a03f8fc36e6c13011a27bcaf028c9c54ba89cd70f485a7d1c687ed", size = 6386, upload-time = "2021-10-20T11:16:47.84Z" },
 ]
 
 [[package]]
@@ -796,24 +719,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "construct"
-version = "2.10.68"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/a4a032e94bcfdff481f2e6fecd472794d9da09f474a2185ed33b2c7cad64/construct-2.10.68.tar.gz", hash = "sha256:7b2a3fd8e5f597a5aa1d614c3bd516fa065db01704c72a1efaaeec6ef23d8b45", size = 57856, upload-time = "2022-02-21T23:09:15.1Z" }
-
-[[package]]
-name = "construct-typing"
-version = "0.5.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "construct" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/5f/89f8e4fc17ea96ef9af66aa4818e00c4fb84c289c4c6879df411d11f15a4/construct-typing-0.5.6.tar.gz", hash = "sha256:0dc501351cd6b308f15ec54e5fe7c0fbc07cc1530a1b77b4303062a0a93c1297", size = 22716, upload-time = "2023-05-09T11:05:50.106Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/c5/d68c7b7e5e2875d199b49f86f9fda2b18a58ff0a835f608cb664bbc3a53e/construct_typing-0.5.6-py3-none-any.whl", hash = "sha256:39c948329e880564e33521cba497b21b07967c465b9c9037d6334e2cffa1ced9", size = 24098, upload-time = "2023-05-09T11:05:48.66Z" },
 ]
 
 [[package]]
@@ -1560,6 +1465,24 @@ wheels = [
 ]
 
 [[package]]
+name = "google-genai"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "google-auth" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/93/4ad189184db21539c625bba432faa3a36e1e5eeb0b3a0b52fbdc9bdac324/google_genai-1.17.0.tar.gz", hash = "sha256:2cf0ff1218290efe6fad80d586cc4aed5a1ca6d38407d1ae221cf10e308c299b", size = 197180, upload-time = "2025-05-28T22:50:06.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/e8/6cc81b481d71f64896964d6aa105f17f13a974627da5d22a3e676fb056b6/google_genai-1.17.0-py3-none-any.whl", hash = "sha256:0a5ba765cc9900a5fa7e71ed4520a1560a857754e72db32765009e2e9fe75333", size = 199245, upload-time = "2025-05-28T22:50:04.852Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1911,15 +1834,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
     { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
     { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
-]
-
-[[package]]
-name = "jsonalias"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/45/ee7e17002cb7f3264f755ff6a1a72c55d1830e07808d643167d2a2277c4f/jsonalias-0.1.1.tar.gz", hash = "sha256:64f04d935397d579fc94509e1fcb6212f2d081235d9d6395bd10baedf760a769", size = 1095, upload-time = "2022-10-28T22:57:56.224Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/ed/05aebce69f78c104feff2ffcdd5a6f9d668a208aba3a8bf56e3750809fd8/jsonalias-0.1.1-py3-none-any.whl", hash = "sha256:a56d2888e6397812c606156504e861e8ec00e188005af149f003c787db3d3f18", size = 1312, upload-time = "2022-10-28T22:57:54.763Z" },
 ]
 
 [[package]]
@@ -2508,22 +2422,6 @@ wheels = [
 ]
 
 [[package]]
-name = "open-aea-ledger-solana"
-version = "2.2.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anchorpy" },
-    { name = "cryptography" },
-    { name = "open-aea" },
-    { name = "solana" },
-    { name = "solders" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/d6/202b92c925b6816f2f8706a0837aafc040c7fedabb54cdc406dfa644dafb/open_aea_ledger_solana-2.2.9.tar.gz", hash = "sha256:32d6f02c2051f8183921e92da51d8e034d2e1d4d2bc845319bb2bad220089ae6", size = 132601, upload-time = "2026-06-24T11:29:50.533Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/08/a0a179887fba660bd49c5a20b8dd58f644ac7745b5fa727ac894e67be96b/open_aea_ledger_solana-2.2.9-py3-none-any.whl", hash = "sha256:40898cb42dc8d15b8d4e49c2ca04999fa47f4d91ec1b9f8ab2ba21d6cb1c8895", size = 28095, upload-time = "2026-06-24T11:29:49.65Z" },
-]
-
-[[package]]
 name = "open-aea-test-autonomy"
 version = "0.21.26"
 source = { registry = "https://pypi.org/simple" }
@@ -2537,7 +2435,7 @@ wheels = [
 
 [[package]]
 name = "open-autonomy"
-version = "0.21.26"
+version = "0.21.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2548,16 +2446,15 @@ dependencies = [
     { name = "multidict" },
     { name = "open-aea", extra = ["all"] },
     { name = "open-aea-ledger-cosmos" },
-    { name = "open-aea-ledger-solana" },
     { name = "protobuf" },
     { name = "py-ecc" },
     { name = "pynacl" },
     { name = "requests" },
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/22/e043fad956c39b804e71c9be23a78331fa483951ebab9297fdfcd503d9d3/open_autonomy-0.21.26.tar.gz", hash = "sha256:ed5960ebe6becc45880b424903ea050f766479e0972836fde597cf41046bc1db", size = 1164487, upload-time = "2026-07-03T12:36:05.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/84/8dfbc4fbad9ae172aeefa415ec8bd4eb4b7ed4a61e66e8858d5eb2d62495/open_autonomy-0.21.27.tar.gz", hash = "sha256:1f53ccf5aee47d937c9ffb1030fb041270ca7883279bf89b8a7c0a69f9d2bd4c", size = 1164887, upload-time = "2026-08-13T15:12:20.648Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/0f/eafc99ec36c056f6a5e58c655577461cfe75562813968fe501507d03e020/open_autonomy-0.21.26-py3-none-any.whl", hash = "sha256:0bdca68a99655f1900987b114d26f97eec021190309ce154375c5c51a80f9869", size = 1674503, upload-time = "2026-07-03T12:36:03.952Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/c0fc6daf8a8d7f178b9230288dd59a9eb91b6b447af4956c3421a7f4c240/open_autonomy-0.21.27-py3-none-any.whl", hash = "sha256:144a58d98b1fa95da191921c6ce2579a5c7b0d7b7ced35209daafdc8b5e52709", size = 1674639, upload-time = "2026-08-13T15:12:19.005Z" },
 ]
 
 [package.optional-dependencies]
@@ -3191,29 +3088,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyheck"
-version = "0.1.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/42/15/888a078f79c832900928fc33eb52218b907c1432b4433c2474b9199b8d02/pyheck-0.1.5.tar.gz", hash = "sha256:5c9fe372d540c5dbcb76bf062f951d998d0e14c906c842a52f1cd5de208e183a", size = 3391, upload-time = "2022-02-18T23:11:59.77Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/3b/733a16d3ffbf8b0786bf3462ada25eea6eb55ec7b512706623f3bb3f202e/pyheck-0.1.5-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:44caf2b7a49d71fdeb0469e9f35886987ad815a8638b3c5b5c83f351d6aed413", size = 295742, upload-time = "2022-02-18T23:11:44.241Z" },
-    { url = "https://files.pythonhosted.org/packages/56/eb/6f35c9a10f6da3b64de58398464b52db9b3205756a66099bc05c673c8ea9/pyheck-0.1.5-cp37-abi3-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:316a842b94beff6e59a97dbcc590e9be92a932e59126b0faa9ac750384f27eaf", size = 583456, upload-time = "2022-02-18T23:11:45.369Z" },
-    { url = "https://files.pythonhosted.org/packages/69/2b/80f335f32851c89a2b5a770928b44195a7cf1f0192ad71d48f7af4430c13/pyheck-0.1.5-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b6169397395ff041f056bfb36c1957a788a1cd7cb967a927fcae7917ff1b6aa", size = 1058932, upload-time = "2022-02-18T23:11:46.443Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c0/9e4c997d2a6b0b96336d53570a40f45c172fc8541b9fdc047031fbfe9ea4/pyheck-0.1.5-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e9d101e1c599227280e34eeccab0414246e70a91a1cabb4c4868dca284f2be7d", size = 1072944, upload-time = "2022-02-18T23:11:47.538Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/4c/f3b15b999531fa0f37553171c60ae2065a0e933e9a526080994747dccc81/pyheck-0.1.5-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:69d6509138909df92b2f2f837518dca118ef08ae3c804044ae511b81b7aecb4d", size = 1201526, upload-time = "2022-02-18T23:11:48.957Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/63/6844333e7734cc4068b5c28b644e5f6c2d0f4d4d886bd6a7fc598d2f4580/pyheck-0.1.5-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ce4a2e1b4778051b8f31183e321a034603f3957b6e95cf03bf5f231c8ea3066", size = 1178330, upload-time = "2022-02-18T23:11:50.093Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e8/1d0df9db32bf80b1e6b42117e0ca15cd8daed0bc6186cae53af633b9083b/pyheck-0.1.5-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69387b70d910637ab6dc8dc378c8e0b4037cee2c51a9c6f64ce5331b010f5de3", size = 1318718, upload-time = "2022-02-18T23:11:51.295Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/36/3f94728c4df3166c098be17153763ab11afef163d0129fe1c1553eaaab43/pyheck-0.1.5-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0fb50b7d899d2a583ec2ac291b8ec2afb10f0e32c4ac290148d3da15927787f8", size = 1093745, upload-time = "2022-02-18T23:11:52.811Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/eb/b424ce465428ead400360cf5f62842b4749d0bc5da0b9a41f7731684da01/pyheck-0.1.5-cp37-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:aa8dfd0883212f8495e0bae6eb6ea670c56f9b197b5fe6fb5cae9fd5ec56fb7c", size = 1057755, upload-time = "2022-02-18T23:11:54.461Z" },
-    { url = "https://files.pythonhosted.org/packages/41/20/1385c7a6c80cbb76bf4c0360fc4089ac6bace41e71f68f77b323c6a29ea1/pyheck-0.1.5-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b7c07506b9591e27f8241bf7a72bc4d5c4ac30dedb332efb87e402e49029f233", size = 1304367, upload-time = "2022-07-18T08:56:53.85Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/15/a0719ae87853e7cf1dba412dc240c32e5dbcf6b3450e01f6d4e52c2ee06e/pyheck-0.1.5-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9ee256cafbdab6c5fcca22d0910176d820bf1e1298773e64f4eea79f51218cc7", size = 1462824, upload-time = "2022-07-18T08:56:55.731Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a6/70892131b9b82a241758698d8a2ab99fcf79118c838867f777c228858b60/pyheck-0.1.5-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:e9ba36060abc55127c3813de398b4013c05be6118cfae3cfa3d978f7b4c84dea", size = 1273243, upload-time = "2022-02-18T23:11:55.459Z" },
-    { url = "https://files.pythonhosted.org/packages/46/79/461a4636c6cfdbf0c90f3d8532db728e3ae117d63765a431aa3f1ebfe66b/pyheck-0.1.5-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:64201a6d213bec443aeb33f66c60cea61aaf6257e48a19159ac69a5afad4768e", size = 1240962, upload-time = "2022-02-18T23:11:56.528Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/2b/1df278fe24e40e5bf13277cd114b47c4e1e498c7850c5ed38f807f945de2/pyheck-0.1.5-cp37-abi3-win32.whl", hash = "sha256:1501fcfd15f7c05c6bfe38915f5e514ac95fc63e945f7d8b089d30c1b8fdb2c5", size = 180706, upload-time = "2022-02-18T23:11:57.572Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/21/07e09ee32556379a2d1c17f680a49f52ee89283d51637743ecffcb232d3b/pyheck-0.1.5-cp37-abi3-win_amd64.whl", hash = "sha256:e519f80a0ef87a8f880bfdf239e396e238dcaed34bec1ea7ef526c4873220e82", size = 193764, upload-time = "2022-02-18T23:11:58.745Z" },
-]
-
-[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3831,60 +3705,12 @@ wheels = [
 ]
 
 [[package]]
-name = "solana"
-version = "0.36.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "construct-typing" },
-    { name = "httpx" },
-    { name = "solders" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/03/7d/ff1006867566c802c8d99b528893bb04b1ec4f9e18191db32e143773e68d/solana-0.36.6.tar.gz", hash = "sha256:aa2403bc36bb06ea5bf56f6856373a50ae8b1c3a45261d5a4c911350f7427c00", size = 52132, upload-time = "2025-02-22T21:17:27.768Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/7a/56650a6771626cd9509b19fb5e26ecd5a4c7057679f803a437f73ea62507/solana-0.36.6-py3-none-any.whl", hash = "sha256:c0526b602d834cb762102f854be469be6657731db0d016a985bbabd6212dd09d", size = 62272, upload-time = "2025-02-22T21:17:26.592Z" },
-]
-
-[[package]]
-name = "solders"
-version = "0.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonalias" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/96/23ad2e43e2676b78834064fe051e3db3ce1899336ecd4797f92fcd06113a/solders-0.26.0.tar.gz", hash = "sha256:057533892d6fa432c1ce1e2f5e3428802964666c10b57d3d1bcaab86295f046c", size = 181123, upload-time = "2025-02-18T19:23:57.734Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/ce/58bbb4d2c696e770cdd37e5f6dc2891ef7610c0c085bf400f9c42dcff1ad/solders-0.26.0-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9c1a0ef5daa1a05934af5fb6e7e32eab7c42cede406c80067fee006f461ffc4a", size = 24344472, upload-time = "2025-02-18T19:23:30.273Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/35/221cec0e5900c2202833e7e9110c3405a2d96ed25e110b247f88b8782e29/solders-0.26.0-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b964efbd7c0b38aef3bf4293ea5938517ae649b9a23e7cd147d889931775aab", size = 6674734, upload-time = "2025-02-18T19:23:35.15Z" },
-    { url = "https://files.pythonhosted.org/packages/41/33/d17b7dbc92672351d59fc65cdb93b8924fc682deba09f6d96f25440187ae/solders-0.26.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36e6a769c5298b887b7588edb171d93709a89302aef75913fe893d11c653739d", size = 13472961, upload-time = "2025-02-18T19:23:38.582Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/e7/533367d815ab000587ccc37d89e154132f63347f02dcaaac5df72bd851de/solders-0.26.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b3cc55b971ec6ed1b4466fa7e7e09eee9baba492b8cd9e3204e3e1a0c5a0c4aa", size = 6886198, upload-time = "2025-02-18T19:23:41.453Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e0/ab41ab3df5fdf3b0e55613be93a43c2fe58b15a6ea8ceca26d3fba02e3c6/solders-0.26.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3e3973074c17265921c70246a17bcf80972c5b96a3e1ed7f5049101f11865092", size = 7319170, upload-time = "2025-02-18T19:23:43.758Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/34/5174ce592607e0ac020aff203217f2f113a55eec49af3db12945fea42d89/solders-0.26.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:59b52419452602f697e659199a25acacda8365971c376ef3c0687aecdd929e07", size = 7134977, upload-time = "2025-02-18T19:23:46.157Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/5e/822faabda0d473c29bdf59fe8869a411fd436af8ca6f5d6e89f7513f682f/solders-0.26.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5946ec3f2a340afa9ce5c2b8ab628ae1dea2ad2235551b1297cafdd7e3e5c51a", size = 6984222, upload-time = "2025-02-18T19:23:49.429Z" },
-    { url = "https://files.pythonhosted.org/packages/23/e8/dc992f677762ea2de44b7768120d95887ef39fab10d6f29fb53e6a9882c1/solders-0.26.0-cp37-abi3-win_amd64.whl", hash = "sha256:5466616610170aab08c627ae01724e425bcf90085bc574da682e9f3bd954900b", size = 5480492, upload-time = "2025-02-18T19:23:53.285Z" },
-]
-
-[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
-]
-
-[[package]]
-name = "sumtypes"
-version = "0.1a6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/aa/1aa52ae948166291cf615687a733151d4567645beac7e51b7bae3fd88ad4/sumtypes-0.1a6.tar.gz", hash = "sha256:1a6ff095e06a1885f340ddab803e0f38e3f9bed81f9090164ca9682e04e96b43", size = 5272, upload-time = "2021-11-30T14:18:43.172Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/29/4ef1ff91dad16f8396bab999a09011d4939951f47b9729b3f73cc1f74756/sumtypes-0.1a6-py2.py3-none-any.whl", hash = "sha256:3e9d71322dd927d25d935072f8be7daec655ea292fd392359a5bb2c1e53dfdc3", size = 5817, upload-time = "2021-11-30T14:18:41.447Z" },
 ]
 
 [[package]]
@@ -3973,15 +3799,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
     { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
     { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
-]
-
-[[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Two threads tied together:

**1. kv_store crash on base_mech in prod.** PR #62 added a \`store_path: \${STORE_PATH:str:/data}\` override at the service.yaml level only. Turned out that wasn't enough — the container was still crashing at boot with \`KvStoreConnection: TypeError expected str, bytes or os.PathLike object, not NoneType\` because the AGENT-level aea-config didn't declare kv_store at all. mech-predict has the override in BOTH places, which is why it boots cleanly.

**2. open-autonomy v0.21.27 released (valory-xyz/open-autonomy#2541 fix).** Moves \`open-aea-ledger-solana\` behind an optional \`[solana]\` extra. mech-agents-fun never used solana, so the whole \`solana → websockets<12\` chain that forced us to stub google-genai in PR #58 no longer applies.

## What

### kv_store fix (agent-level)

- \`aea-config.yaml\`: declare \`valory/kv_store:0.1.0\` in both \`connections:\` and \`protocols:\` lists, plus the config override block:
  \`\`\`yaml
  ---
  public_id: valory/kv_store:0.1.0
  type: connection
  config:
    store_path: \${str:/data}
  \`\`\`
- \`service.yaml\` override from PR #62 stays (mech-predict has both; belt-and-braces).

Evidence for why both are needed:
- \`docker run --rm valory/oar-mech_agents_fun:0.3.7 cat /home/agent/aea-config.yaml | grep -A 3 kv_store\` → no override
- \`docker run --rm valory/oar-mech_predict:v0.21.22 cat /home/agent/aea-config.yaml | grep -A 3 kv_store\` → override present at agent level, which is what makes mech-predict boot cleanly

### open-autonomy 0.21.27 + un-stub google tools

- \`pyproject.toml\`: \`open-autonomy[all]\` bumped \`0.21.26\` → \`0.21.27\`; re-adds \`google-genai==1.17.0\` and \`google-api-core>=2.20.0,<3\`; drops the uv-only \`override-dependencies\` block that forced \`solana>=0.36\` (no longer needed since solana isn't pulled at all).
- \`tox.ini\`: \`[Authorized Packages] open-autonomy\` bumped to \`0.21.27\`.
- \`aea-config.yaml\`: adds \`google-genai==1.17.0\` and \`google-api-core\` deps back, bumps \`open-aea-test-autonomy\` to \`==0.21.27\`.
- \`google_image_gen.py\` + \`google_video_gen.py\`: restored to their original google-genai-based implementations (imports, \`run()\`, all helpers). PR #58's stub goes away.
- \`google_image_gen/component.yaml\` + \`google_video_gen/component.yaml\`: original deps restored (google-genai, google-api-core, pillow, open-aea-cli-ipfs, anthropic, openai + moviepy/requests for video).

### Kept from earlier PRs

- \`valory/superforcaster\` custom tool (added in PR #58 as filler while google-genai was stubbed — retained per team decision).
- All service.yaml settings from PR #62.

### Not touched

\`.github/workflows/release.yaml\` stays on \`valory/open-autonomy-user:0.21.26\` because \`0.21.27\` isn't published to Docker Hub yet. The outer container just runs the autonomy CLI to publish/build; the inner docker build's pip install pulls open-autonomy \`0.21.27\` via \`open-aea-test-autonomy==0.21.27\`'s constraint, so the release still ends up running the new version. Can bump the outer once the 0.21.27 user image lands.

## New hashes

- Agent: \`bafybeialwz2ymre5v2y263umrud7ovd4up3aila7ha5bvaxqqs4yxrewpa\`
- Service: \`bafybeihnuvxjwhfepcdgbnlwey2cjsmcsagxnwjuhkul32hllvxhbzz5ve\`

## Verified locally

- \`autonomy packages lock --check\` — OK
- \`uv lock --check\` — OK (153 packages resolved; \`solana\` removed from the graph)
- \`pip install --dry-run\` in \`valory/open-autonomy:0.21.26\` base with pip 26.2.1 and \`open-aea-test-autonomy==0.21.27 + google-genai==1.17.0\` — EXIT=0
- \`black-check\` / \`isort-check\` / \`flake8\` / \`mypy\` — OK

## Test plan

- [ ] CI on this PR passes
- [ ] Cut v0.3.8 release; Docker image builds without pip resolution errors
- [ ] Redeploy base_mech via propel with v0.3.8 service hash
- [ ] Confirm agent boots past kv_store (no more crash loop)
- [ ] Confirm google_image_gen (and short_maker / stability / superforcaster) all dispatch correctly