### PR TITLE
fix(service): declare aea_version 2.x in service.yaml (was stale 1.x)

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,7 +7,7 @@
         "custom/agents_fun/google_video_gen/0.1.0": "bafybeifqegajjjjfcxc6yc6jebl3x4dchcxlpw2o5kxxtadtguu2hipy2e",
         "custom/valory/superforcaster/0.1.0": "bafybeidwdixsstuexhtgrzhl5tpcx2ezkvb2oace62z32ty52z5wdradna",
         "agent/valory/mech_agents_fun/0.1.0": "bafybeialwz2ymre5v2y263umrud7ovd4up3aila7ha5bvaxqqs4yxrewpa",
-        "service/valory/mech_agents_fun/0.1.0": "bafybeihnuvxjwhfepcdgbnlwey2cjsmcsagxnwjuhkul32hllvxhbzz5ve"
+        "service/valory/mech_agents_fun/0.1.0": "bafybeif22kfrpnpwpjl33maog4lry3nnqghiphmhfyi36p65m5oglytgeq"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeiea66z4k6cgcazxd6qzvnkllulyjzbnxufkoenge7qzh4qfogrvoa",

--- a/packages/valory/services/mech_agents_fun/service.yaml
+++ b/packages/valory/services/mech_agents_fun/service.yaml
@@ -2,7 +2,7 @@ name: mech_agents_fun
 author: valory
 version: 0.1.0
 description: A decentralised task execution engine.
-aea_version: '>=1.0.0, <2.0.0'
+aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba


### PR DESCRIPTION
## Hypothesis

base_mech v0.3.8 still crashes on kv_store even with the store_path override correctly baked into \`aea-config.yaml\` and \`service.yaml\`. Deep diff against mech-predict (which works) found one real difference:

| | service.yaml \`aea_version\` |
|---|---|
| mech-agents-fun v0.3.8 | \`>=1.0.0, <2.0.0\` (stale, aea 1.x era) |
| mech-predict | \`>=2.0.0, <3.0.0\` |
| upstream mech (v0.34.8) | \`>=2.0.0, <3.0.0\` |
| mech-agents-fun aea-config.yaml | \`>=2.0.0, <3.0.0\` (already correct) |
| runtime aea in container | 2.2.9 |

Very plausible cause of the persistent crash: autonomy's config-override applier gates each override block by \`aea_version\` compat. mech-agents-fun's service.yaml declares 1.x while the runtime is 2.x → the \`kv_store store_path\` service-level override gets silently dropped at deploy build time → \`aea-config.yaml\` should still carry the same override at agent level, but if the deploy pipeline uses \`service.yaml\` as the source of truth for the container's baked config, only the (dropped) service.yaml override matters. Result: connection.yaml default \`store_path: null\` wins → \`Path(None)\` → the same \`TypeError\` we've been chasing.

## What

Single-line change: \`aea_version: '>=1.0.0, <2.0.0'\` → \`aea_version: '>=2.0.0, <3.0.0'\` in \`packages/valory/services/mech_agents_fun/service.yaml\`. Aligns with agent's aea-config, upstream mech's service.yaml, and the actual runtime.

Regenerates the service hash.

## New service hash

\`bafybeif22kfrpnpwpjl33maog4lry3nnqghiphmhfyi36p65m5oglytgeq\`

## Verified locally

- \`autonomy packages lock --check\` — OK

## Test plan

- [ ] CI passes
- [ ] Cut v0.3.9 release
- [ ] Bump base_mech.env in agent-deployments to the new service hash
- [ ] Redeploy base_mech via propel — the agent should boot past kv_store (11-cycle crash loop clears)